### PR TITLE
[iOS] - Adaptive Cards visual Improvements and fixes

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
@@ -19,7 +19,8 @@ NSString *uncheckedCheckboxReuseID = @"unchecked-checkbox";
 NSString *checkedRadioButtonReuseID = @"checked-radiobutton";
 NSString *uncheckedRadioButtonReuseID = @"unchecked-radiobutton";
 
-const CGFloat padding = 2.0f;
+const CGFloat padding = 12.0f;
+const CGFloat verticalPadding = 16.0f;
 
 @implementation ACRChoiceSetCell {
     CGSize _imageSize;
@@ -270,7 +271,7 @@ const CGFloat padding = 2.0f;
                                  context:nil]
             .size;
 
-    return labelStringSize.height + _spacing;
+    return labelStringSize.height + _spacing + verticalPadding;
 }
 
 - (BOOL)validate:(NSError **)error

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
@@ -19,8 +19,8 @@ NSString *uncheckedCheckboxReuseID = @"unchecked-checkbox";
 NSString *checkedRadioButtonReuseID = @"checked-radiobutton";
 NSString *uncheckedRadioButtonReuseID = @"unchecked-radiobutton";
 
-const CGFloat padding = 12.0f;
-const CGFloat verticalPadding = 16.0f;
+const CGFloat padding = 8.0f;
+const CGFloat minimumRowHeight = 44.0;
 
 @implementation ACRChoiceSetCell {
     CGSize _imageSize;
@@ -270,8 +270,10 @@ const CGFloat verticalPadding = 16.0f;
                               attributes:@{NSFontAttributeName : cell.textLabel.font}
                                  context:nil]
             .size;
-
-    return labelStringSize.height + _spacing + verticalPadding;
+    
+    CGFloat rowHeight = labelStringSize.height + _spacing;
+    
+    return (rowHeight < minimumRowHeight) ? minimumRowHeight : rowHeight;
 }
 
 - (BOOL)validate:(NSError **)error


### PR DESCRIPTION
Visual improvements requested by design team:

Increased height of choice set cell to 44 px
Additional separation between choice icon and text (8 px)

Before:

![Simulator Screenshot - iPhone 14 - 2023-09-29 at 15 21 39](https://github.com/microsoft/AdaptiveCards-Mobile/assets/130393016/8547f5dc-2f5c-4e0c-a79d-3c4876148d47)

After:

![Simulator Screenshot - iPhone 14 - 2023-10-04 at 16 19 56](https://github.com/microsoft/AdaptiveCards-Mobile/assets/130393016/a3a9ba22-5d8a-4726-b5e3-011a5e08e483)
