### PR TITLE
Added preliminary support for visionOS

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
@@ -296,9 +296,6 @@ static inline CGRect ActiveSceneBoundsForView(UIView *view)
 - (void)layoutFilterredView
 {
     CGPoint position = [self.superview convertPoint:self.frame.origin toView:nil];
-#if !TARGET_OS_VISION
-    CGSize windowSize = (self.window) ? self.window.bounds.size : UIScreen.mainScreen.bounds.size;
-#else
     CGSize windowSize;
     if (self.window != nil)
     {
@@ -309,7 +306,6 @@ static inline CGRect ActiveSceneBoundsForView(UIView *view)
         CGRect sceneBounds = ActiveSceneBoundsForView(self);
         windowSize = sceneBounds.size;
     }
-#endif
 
     UIViewController *viewController = traverseResponderChainForUIViewController(_rootView);
     CGRect frame = viewController.view.frame;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
@@ -19,6 +19,55 @@
 
 using namespace AdaptiveCards;
 
+static inline CGRect ActiveScreenBounds()
+{
+    // this code is also compiled for extensions where UIApplication.sharedApplication is not available
+    UIApplication *sharedApp = nil;
+    if ([UIApplication respondsToSelector:NSSelectorFromString(@"sharedApplication")])
+    {
+        sharedApp = [UIApplication performSelector:NSSelectorFromString(@"sharedApplication")];
+    }
+    
+    UIWindowScene *activeScene = nil;
+    for (UIWindowScene *scene in sharedApp.connectedScenes)
+    {
+        if (scene.activationState == UISceneActivationStateForegroundActive)
+        {
+            activeScene = scene;
+            break;
+        }
+    }
+
+    if ((activeScene == nil) && (sharedApp.connectedScenes.count > 0))
+    {
+        activeScene = (UIWindowScene *)sharedApp.connectedScenes.anyObject;
+    }
+
+    if (activeScene != nil)
+    {
+        return activeScene.coordinateSpace.bounds;
+    }
+#if !TARGET_OS_VISION
+    else
+    {
+        return UIScreen.mainScreen.bounds;
+    }
+#endif
+    return CGRectZero;
+
+}
+
+static inline CGRect ActiveSceneBoundsForView(UIView *view)
+{
+    UIWindowScene *activeScene = view.window.windowScene;
+    if(activeScene != nil)
+    {
+        return activeScene.coordinateSpace.bounds;
+    }
+    
+    return ActiveScreenBounds();
+}
+
 @implementation ACRChoiceSetCompactStyleView {
     ACOFilteredDataSource *_filteredDataSource;
     ACOFilteredListStateManager *_stateManager;
@@ -247,7 +296,20 @@ using namespace AdaptiveCards;
 - (void)layoutFilterredView
 {
     CGPoint position = [self.superview convertPoint:self.frame.origin toView:nil];
+#if !TARGET_OS_VISION
     CGSize windowSize = (self.window) ? self.window.bounds.size : UIScreen.mainScreen.bounds.size;
+#else
+    CGSize windowSize;
+    if (self.window != nil)
+    {
+        windowSize = self.window.bounds.size;
+    }
+    else
+    {
+        CGRect sceneBounds = ActiveSceneBoundsForView(self);
+        windowSize = sceneBounds.size;
+    }
+#endif
 
     UIViewController *viewController = traverseResponderChainForUIViewController(_rootView);
     CGRect frame = viewController.view.frame;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRDateTextField.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRDateTextField.mm
@@ -133,6 +133,7 @@ using namespace AdaptiveCards;
 
         [picker addTarget:self action:@selector(update:) forControlEvents:UIControlEventValueChanged];
 
+#if !TARGET_OS_VISION
         UIBarButtonItem *button = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
                                                                                 target:self
                                                                                 action:@selector(dismiss)];
@@ -143,6 +144,7 @@ using namespace AdaptiveCards;
         button.tintColor = [UIColor blackColor];
 
         self.inputAccessoryView = bar;
+#endif
         self.inputView = picker;
         self.hasValidationProperties = self.isRequired || self.max || self.min;
     }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
@@ -52,6 +52,7 @@
         }
         case TextInputStyle::Tel: {
             txtInput = [bundle loadNibNamed:@"ACRTextTelelphoneField" owner:rootView options:nil][0];
+#if !TARGET_OS_VISION
             CGRect frame = CGRectMake(0, 0, viewGroup.frame.size.width, 30);
             UIToolbar *toolBar = [[UIToolbar alloc] initWithFrame:frame];
             UIBarButtonItem *flexSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
@@ -59,6 +60,7 @@
             [toolBar setItems:@[ doneButton, flexSpace ] animated:NO];
             [toolBar sizeToFit];
             txtInput.inputAccessoryView = toolBar;
+#endif
             break;
         }
         case TextInputStyle::Url: {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaTarget.mm
@@ -209,6 +209,18 @@ const int posterTag = 0x504F5354;
 
 - (void)playVideoWhenTrackIsReady:(AVURLAsset *)asset
 {
+#if !TARGET_OS_VISION
+    AVAssetTrack *track = [asset tracksWithMediaCharacteristic:AVMediaCharacteristicVisual][0];
+    [track loadValuesAsynchronouslyForKeys:@[ @"naturalSize" ]
+                         completionHandler:^{
+        AVKeyValueStatus status = [asset statusOfValueForKey:@"naturalSize" error:nil];
+        if (status == AVKeyValueStatusLoaded) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self playMedia:track asset:asset];
+            });
+        }
+    }];
+#else
     [asset loadTracksWithMediaCharacteristic:AVMediaCharacteristicVisual completionHandler:^(NSArray<AVAssetTrack *> *tracks, NSError *err) {
         AVAssetTrack *track = tracks[0];
         [track loadValuesAsynchronouslyForKeys:@[ @"naturalSize" ]
@@ -221,6 +233,7 @@ const int posterTag = 0x504F5354;
             }
         }];
     }];
+#endif
 }
 
 - (void)playMedia:(AVAssetTrack *)track asset:(AVURLAsset *)asset

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaTarget.mm
@@ -209,16 +209,32 @@ const int posterTag = 0x504F5354;
 
 - (void)playVideoWhenTrackIsReady:(AVURLAsset *)asset
 {
-    AVAssetTrack *track = [asset tracksWithMediaCharacteristic:AVMediaCharacteristicVisual][0];
-    [track loadValuesAsynchronouslyForKeys:@[ @"naturalSize" ]
-                         completionHandler:^{
-                             AVKeyValueStatus status = [asset statusOfValueForKey:@"naturalSize" error:nil];
-                             if (status == AVKeyValueStatusLoaded) {
-                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                     [self playMedia:track asset:asset];
-                                 });
-                             }
-                         }];
+    if (@available(iOS 15.0, *)) {
+        [asset loadTracksWithMediaCharacteristic:AVMediaCharacteristicVisual completionHandler:^(NSArray<AVAssetTrack *> *tracks, NSError *err) {
+            AVAssetTrack *track = tracks[0];
+            [track loadValuesAsynchronouslyForKeys:@[ @"naturalSize" ]
+                                 completionHandler:^{
+                AVKeyValueStatus status = [asset statusOfValueForKey:@"naturalSize" error:nil];
+                if (status == AVKeyValueStatusLoaded) {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [self playMedia:track asset:asset];
+                    });
+                }
+            }];
+        }];
+    } else {
+        // Fallback on earlier versions
+        AVAssetTrack *track = [asset tracksWithMediaCharacteristic:AVMediaCharacteristicVisual][0];
+        [track loadValuesAsynchronouslyForKeys:@[ @"naturalSize" ]
+                             completionHandler:^{
+                                 AVKeyValueStatus status = [asset statusOfValueForKey:@"naturalSize" error:nil];
+                                 if (status == AVKeyValueStatusLoaded) {
+                                     dispatch_async(dispatch_get_main_queue(), ^{
+                                         [self playMedia:track asset:asset];
+                                     });
+                                 }
+                             }];
+    }
 }
 
 - (void)playMedia:(AVAssetTrack *)track asset:(AVURLAsset *)asset

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaTarget.mm
@@ -209,32 +209,18 @@ const int posterTag = 0x504F5354;
 
 - (void)playVideoWhenTrackIsReady:(AVURLAsset *)asset
 {
-    if (@available(iOS 15.0, *)) {
-        [asset loadTracksWithMediaCharacteristic:AVMediaCharacteristicVisual completionHandler:^(NSArray<AVAssetTrack *> *tracks, NSError *err) {
-            AVAssetTrack *track = tracks[0];
-            [track loadValuesAsynchronouslyForKeys:@[ @"naturalSize" ]
-                                 completionHandler:^{
-                AVKeyValueStatus status = [asset statusOfValueForKey:@"naturalSize" error:nil];
-                if (status == AVKeyValueStatusLoaded) {
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        [self playMedia:track asset:asset];
-                    });
-                }
-            }];
-        }];
-    } else {
-        // Fallback on earlier versions
-        AVAssetTrack *track = [asset tracksWithMediaCharacteristic:AVMediaCharacteristicVisual][0];
+    [asset loadTracksWithMediaCharacteristic:AVMediaCharacteristicVisual completionHandler:^(NSArray<AVAssetTrack *> *tracks, NSError *err) {
+        AVAssetTrack *track = tracks[0];
         [track loadValuesAsynchronouslyForKeys:@[ @"naturalSize" ]
                              completionHandler:^{
-                                 AVKeyValueStatus status = [asset statusOfValueForKey:@"naturalSize" error:nil];
-                                 if (status == AVKeyValueStatusLoaded) {
-                                     dispatch_async(dispatch_get_main_queue(), ^{
-                                         [self playMedia:track asset:asset];
-                                     });
-                                 }
-                             }];
-    }
+            AVKeyValueStatus status = [asset statusOfValueForKey:@"naturalSize" error:nil];
+            if (status == AVKeyValueStatusLoaded) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self playMedia:track asset:asset];
+                });
+            }
+        }];
+    }];
 }
 
 - (void)playMedia:(AVAssetTrack *)track asset:(AVURLAsset *)asset

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextView.mm
@@ -54,6 +54,7 @@
 
     self.frame = [self computeBoundingRect];
 
+#if !TARGET_OS_VISION
     CGRect frame = CGRectMake(0, 0, self.frame.size.width, 30);
     UIToolbar *toolBar = [[UIToolbar alloc] initWithFrame:frame];
     UIBarButtonItem *flexSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
@@ -61,6 +62,7 @@
     [toolBar setItems:@[ doneButton, flexSpace ] animated:NO];
     [toolBar sizeToFit];
     self.inputAccessoryView = toolBar;
+#endif
 }
 
 - (BOOL)textViewShouldEndEditing:(UITextView *)textView

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTypeaheadSearchViewController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTypeaheadSearchViewController.mm
@@ -133,7 +133,9 @@ static CGFloat const ACOStackViewSpacing = 14.0f;
     _listView.dataSource = self;
     _listView.delegate = self;
     _listView.accessibilityIdentifier = [NSString stringWithFormat:@"%@, %@", @"listView", [_choiceSetDelegate getChoiceSetId]];
+#if !TARGET_OS_VISION
     _listView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
+#endif
     self.filteredListView = _listView;
     [_container addArrangedSubview:_searchBar];
     [_container addArrangedSubview:_searchBarSeparator];


### PR DESCRIPTION
Added preliminary support for visionOS targets.

**Quick list of changes**

**iOS Specific**
- Added visionOS friendly window size calculation in "_ACRChoiceSetCompactStyleView_".
- Prevent visionOS unsupported UIKit button item usage in "_ACRDateTextField_"
- Prevent visionOS unsupported UIKit button item usage in "_ACRInputRenderer_"
- Update AVAsset video playing logic in "_ACRMediaTarget_" to conditionally utilize updated AVMedia asynchronous loading method