### PR TITLE
[iOS] Responsive Layout integration.

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -23,6 +23,7 @@
 // if the width for Adaptive Cards is zero, the width is determined by the contraint(s) set externally on the card.
 CGFloat kAdaptiveCardsWidth = 0;
 CGFloat kFileBrowserWidth = 0;
+int hostCardContainer = 500;
 
 @interface ViewController () {
     id<ACRIBaseActionSetRenderer> _defaultRenderer;
@@ -129,6 +130,9 @@ CGFloat kFileBrowserWidth = 0;
 
     CustomActionNewTypeRenderer *customActionRenderer = [CustomActionNewTypeRenderer getInstance];
     [registration setCustomActionRenderer:customActionRenderer key:type1];
+    
+    // Required registration for testing responsive layout
+    [registration registerHostCardContainer:hostCardContainer];
 
     self.ACVTabVC = [[ACVTableViewController alloc] init];
     [self addChildViewController:self.ACVTabVC];

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/filebrowserHostConfig.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/filebrowserHostConfig.json
@@ -248,5 +248,10 @@
 	"media": {
         "playButton" : "http://adaptivecards.io/content/adaptive-card-50.png",
 		"allowInlinePlayback" : true
-	}
+	},
+    "hostWidthBreakpoints": {
+          "veryNarrow": 216,
+          "narrow": 413,
+          "standard": 500
+    }
 }

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
@@ -6,7 +6,12 @@
 		"large": 30,
 		"extraLarge": 40,
 		"padding": 10
-	},	
+	},
+    "hostWidthBreakpoints": {
+          "veryNarrow": 216,
+          "narrow": 413,
+          "standard": 500
+    },
 	"supportsInteractivity": true,
 	"imageBaseUrl": "https://pbs.twimg.com/profile_images/3647943215/",
 	"fontTypes": {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.mm
@@ -41,6 +41,11 @@
     std::shared_ptr<HostConfig> config = [acoConfig getHostConfig];
     std::shared_ptr<BaseCardElement> elem = [acoElem element];
     std::shared_ptr<ColumnSet> columnSetElem = std::dynamic_pointer_cast<ColumnSet>(elem);
+    
+    // Get responsive layout's host width
+    ACRRegistration *reg = [ACRRegistration getInstance];
+    HostWidthConfig hostWidthConfig = config->getHostWidth();
+    HostWidth hostWidth = convertHostCardContainerToHostWidth([reg getHostCardContainer], hostWidthConfig);
 
     [rootView.context pushBaseCardElementContext:acoElem];
 
@@ -107,10 +112,13 @@
         [acoColumn setElem:column];
 
         @try {
-            if ([acoElem meetsRequirements:featureReg] == NO) {
+            if ([acoColumn meetsRequirements:featureReg] == NO) {
                 @throw [ACOFallbackException fallbackException];
             }
-
+            if (column->MeetsTargetWidthRequirement(hostWidth) == false){
+                @throw [ACOFallbackException fallbackException];
+            }
+            
             if (lastColumn == column) {
                 columnSetView.isLastColumn = YES;
             }
@@ -123,8 +131,8 @@
             }
         } @catch (ACOFallbackException *e) {
 
-            handleFallbackException(e, columnSetView, rootView, inputs, column, acoConfig);
-
+            handleFallbackException(e, columnSetView, rootView, inputs, column, acoConfig, column->CanFallbackToAncestor());
+            
             if (separator) {
                 [columnSetView removeViewFromContentStackView:separator];
             }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
@@ -60,6 +60,10 @@
 
 - (ACOParseContext *_Nonnull)getParseContext;
 
+- (int)getHostCardContainer;
+
+- (void)registerHostCardContainer:(int)hostCardContainer;
+
 @end
 
 @interface ACOFeatureRegistration : NSObject

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.mm
@@ -58,6 +58,7 @@ using namespace AdaptiveCards;
     NSMutableSet *_useResourceResolverActionsSet;
     id<ACRIBaseActionSetRenderer> _defaultActionSetRenderer;
     ACOParseContext *_parseContext;
+    int _hostCardContainer;
 }
 
 - (instancetype)init
@@ -108,6 +109,8 @@ using namespace AdaptiveCards;
 
         _useResourceResolverElementsSet = [[NSMutableSet alloc] init];
         _useResourceResolverActionsSet = [[NSMutableSet alloc] init];
+        
+        _hostCardContainer = -1;
     }
     return self;
 }
@@ -319,6 +322,16 @@ using namespace AdaptiveCards;
 - (BOOL)checkResourceResolverSet:(NSNumber *)key isAction:(BOOL)isAction
 {
     return (isAction) ? [_useResourceResolverActionsSet containsObject:key] : [_useResourceResolverElementsSet containsObject:key];
+}
+
+- (int)getHostCardContainer
+{
+    return _hostCardContainer;
+}
+
+- (void)registerHostCardContainer:(int)hostCardContainer
+{
+    _hostCardContainer = hostCardContainer;
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
@@ -167,6 +167,10 @@ using namespace AdaptiveCards;
     ACRRegistration *reg = [ACRRegistration getInstance];
     ACOBaseCardElement *acoElem = [[ACOBaseCardElement alloc] init];
     ACOFeatureRegistration *featureReg = [ACOFeatureRegistration getInstance];
+    
+    // Get responsive layout's host width
+    HostWidthConfig hostWidthConfig = [config getHostConfig]->getHostWidth();
+    HostWidth hostWidth = convertHostCardContainerToHostWidth([reg getHostCardContainer], hostWidthConfig);
 
     UIView *renderedView = nil;
 
@@ -191,7 +195,10 @@ using namespace AdaptiveCards;
         [acoElem setElem:elem];
 
         @try {
-            if ([acoElem meetsRequirements:featureReg] == NO) {
+            if ([acoElem meetsRequirements:featureReg] == NO){
+                @throw [ACOFallbackException fallbackException];
+            }
+            if (elem->MeetsTargetWidthRequirement(hostWidth) == false){
                 @throw [ACOFallbackException fallbackException];
             }
 
@@ -205,7 +212,7 @@ using namespace AdaptiveCards;
         } @catch (ACOFallbackException *e) {
             
             @try {
-                handleFallbackException(e, view, rootView, inputs, elem, config);
+                handleFallbackException(e, view, rootView, inputs, elem, config, true);
                 
             } @catch (ACOFallbackException *e) {
                 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/UtiliOS.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/UtiliOS.h
@@ -82,7 +82,7 @@ UIFontDescriptor *getItalicFontDescriptor(UIFontDescriptor *descriptor, bool isI
 
 void handleFallbackException(ACOFallbackException *exception, UIView<ACRIContentHoldingView> *view,
                              ACRView *rootView, NSMutableArray *inputs,
-                             std::shared_ptr<BaseCardElement> const &elem, ACOHostConfig *config);
+                             std::shared_ptr<BaseCardElement> const &elem, ACOHostConfig *config, bool canFallbackToAncestor);
 
 bool handleRootFallback(std::shared_ptr<AdaptiveCard> const &adaptiveCard,
                         UIView<ACRIContentHoldingView> *view,
@@ -159,3 +159,5 @@ id traverseResponderChainForUIViewController(UIView *view);
 CGRect FindClosestRectToCover(CGRect coverRect, CGRect targetRectToCover);
 
 void addSelectActionToView(ACOHostConfig *acoConfig, ACOBaseActionElement *acoSelectAction, ACRView *rootView, UIView *view, UIView<ACRIContentHoldingView> *viewGroup);
+
+HostWidth convertHostCardContainerToHostWidth(int hostCardContainer, HostWidthConfig& hostWidthConfig);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -447,11 +447,11 @@ ObserverActionBlock generateBackgroundImageObserverAction(
 void handleFallbackException(ACOFallbackException *exception, UIView<ACRIContentHoldingView> *view,
                              ACRView *rootView, NSMutableArray *inputs,
                              std::shared_ptr<BaseCardElement> const &givenElem,
-                             ACOHostConfig *config)
+                             ACOHostConfig *config,
+                             bool canFallbackToAncestor)
 {
     std::shared_ptr<BaseElement> fallbackBaseElement = nullptr;
     std::shared_ptr<BaseCardElement> elem = givenElem;
-    bool bCanFallbackToAncestor = elem->CanFallbackToAncestor();
     FallbackType fallbackType = elem->GetFallbackType();
     bool bHandled = false;
     ACRRegistration *reg = [ACRRegistration getInstance];
@@ -493,7 +493,7 @@ void handleFallbackException(ACOFallbackException *exception, UIView<ACRIContent
     } while (!bHandled);
 
     if (!bHandled) {
-        if (fallbackType != FallbackType::Drop) {
+        if (canFallbackToAncestor && fallbackType != FallbackType::Drop) {
             @throw exception;
         } else {
             const CardElementType elemType = givenElem->GetElementType();
@@ -1128,4 +1128,26 @@ void addSelectActionToView(ACOHostConfig *acoConfig, ACOBaseActionElement *acoSe
     if (target && acoSelectAction.inlineTooltip) {
         [target addGestureRecognizer:view toolTipText:acoSelectAction.inlineTooltip];
     }
+}
+
+HostWidth convertHostCardContainerToHostWidth(int hostCardContainer, HostWidthConfig& hostWidthConfig)
+{
+    if (hostCardContainer <= 0 || hostWidthConfig.veryNarrow == 0 || hostWidthConfig.narrow == 0 || hostWidthConfig.standard == 0)
+    {
+        return HostWidth::Default;
+    }
+
+    HostWidth hostWidth;
+
+    if (hostCardContainer <= hostWidthConfig.veryNarrow) {
+        hostWidth = HostWidth::VeryNarrow;
+    } else if (hostCardContainer > hostWidthConfig.veryNarrow && hostCardContainer <= hostWidthConfig.narrow) {
+        hostWidth = HostWidth::Narrow;
+    } else if (hostCardContainer > hostWidthConfig.narrow && hostCardContainer <= hostWidthConfig.standard) {
+        hostWidth = HostWidth::Standard;
+    } else {
+        hostWidth = HostWidth::Wide;
+    }
+
+    return hostWidth;
 }


### PR DESCRIPTION
Added support for responsive layout in iOS. Similar behaviour to existing Android integration (https://github.com/microsoft/AdaptiveCards-Mobile/pull/52).

**Tests using iOS visualizer**

host card container equals to 200:

![Screenshot 2023-12-07 at 12 29 07 p m](https://github.com/microsoft/AdaptiveCards-Mobile/assets/130393016/6824575a-0ddb-4aea-8bc8-dee0a8068584)

host card container equals to 300:

![Screenshot 2023-12-07 at 12 29 20 p m](https://github.com/microsoft/AdaptiveCards-Mobile/assets/130393016/e69e8d52-5152-44c4-b4ad-23104c208874)

host card container equals to 500:

![Screenshot 2023-12-07 at 12 29 31 p m](https://github.com/microsoft/AdaptiveCards-Mobile/assets/130393016/c2783714-5ac2-430b-89ee-b9c5ae5d409e)