### PR TITLE
[iOS] - Fixed card size with limited number of lines

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
@@ -123,8 +123,6 @@
 
     lab.translatesAutoresizingMaskIntoConstraints = NO;
 
-    [viewGroup addArrangedSubview:lab];
-
     lab.textContainer.maximumNumberOfLines = int(txtBlck->GetMaxLines());
     if (!lab.textContainer.maximumNumberOfLines && !txtBlck->GetWrap()) {
         lab.textContainer.maximumNumberOfLines = 1;
@@ -135,7 +133,7 @@
     }
 
     lab.editable = NO;
-
+    
     [lab setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
 
     if (txtBlck->GetHeight() == HeightType::Auto) {
@@ -143,8 +141,10 @@
     } else {
         [lab setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisVertical];
     }
-
+    
     configRtl(lab, rootView.context);
+    
+    [viewGroup addArrangedSubview:lab];
 
     return lab;
 }


### PR DESCRIPTION
**Issue**
Adaptive Card with long text and limited number of lines displays wrong height with empty space.

**Fix**
The View is being added to the StackView before configuring the max lines, which produces bad height. Moving the addition to the end fix the problem.

**Validation**
Manual Validation

Before:
![Simulator Screenshot - iPhone 15 - 2024-01-08 at 13 47 34](https://github.com/microsoft/AdaptiveCards-Mobile/assets/130393016/6a461ede-adc1-4570-8d27-3ad951ce8279)

After:
![Simulator Screenshot - iPhone 15 - 2024-01-08 at 13 46 00](https://github.com/microsoft/AdaptiveCards-Mobile/assets/130393016/395fb4a0-3043-4e6d-9a25-259d2c55ce8c)

