### PR TITLE
[iOS] fix voiceover duplicates for labels

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
@@ -116,6 +116,11 @@
         lab.textContainer.lineBreakMode = NSLineBreakByTruncatingTail;
         lab.attributedText = content;
         lab.accessibilityLabel = content.string;
+        // if accessibility label is the same as accessibility value, clear accessibility value
+        // this prevents the same content from being repeated twice in voiceover
+        if (lab.accessibilityValue != nil && [lab.accessibilityValue isEqualToString:lab.accessibilityLabel]) {
+            lab.accessibilityValue = @"";
+        }
         if ([content.string stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet].length == 0) {
             lab.accessibilityElementsHidden = YES;
         }


### PR DESCRIPTION
# Related Issue

Fixes Issue: https://github.com/microsoft/AdaptiveCards-Mobile/issues/24

# Description

A11Y voiceover announces the same piece of content twice when the accessibility label and accessibility value are the same. 

The fix is to clear the accessibility value if accessibility label and accessibility value are the same.

# How Verified

<img width="373" alt="image" src="https://github.com/microsoft/AdaptiveCards-Mobile/assets/42756862/d958ce91-fefd-42eb-b8cf-8373aca6308b">

A11Y Inspector Before:
<img width="333" alt="image" src="https://github.com/microsoft/AdaptiveCards-Mobile/assets/42756862/6dfa9d83-fe9e-486f-9b7b-ca2e88c32b80">

A11Y Inspector After:
<img width="341" alt="image" src="https://github.com/microsoft/AdaptiveCards-Mobile/assets/42756862/12f4d7de-b22e-4042-8981-8202d793db81">