### PR TITLE
[iOS] - Fixed parsing detection for asterisk.

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/UtiliOS.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/UtiliOS.h
@@ -164,3 +164,6 @@ HostWidth convertHostCardContainerToHostWidth(int hostCardContainer, HostWidthCo
 
 // Validate date of type "YYYY. MM. DD. HH:MM AM|PM" to prevent parsing issues
 bool matchHungarianDateRegex(NSString *stringToValidate);
+
+// Retuns a string with removed symbols of type \\x
+NSString* stringWithRemovedBackslashedSymbols(NSString *stringToRemoveSymbols, NSSet<NSString *> *symbolsSet);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -743,7 +743,12 @@ void buildIntermediateResultForText(ACRView *rootView, ACOHostConfig *hostConfig
                                                                   options:NSRegularExpressionSearch
                                                                     range:NSMakeRange(0, [parsedString length])];
     }
-
+    // Added manual replace of \\* when the text is used directly, html parsing is exluding this case successfully
+    if (!markDownParser->HasHtmlTags() && [parsedString containsString:@"\\*"]) {
+        parsedString = [parsedString stringByReplacingOccurrencesOfString:@"\\*"
+                                                               withString:@"*"];
+    }
+    
     NSDictionary *data = nil;
 
     FontType sharedFontType = textProperties.GetFontType().value_or(FontType::Default);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsUtiliOSTest.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsUtiliOSTest.mm
@@ -61,4 +61,17 @@ using namespace AdaptiveCards;
     XCTAssertFalse(matchHungarianDateRegex(diffDateFormat2));
 }
 
+- (void)testStringWithRemovedBackslashedSymbols
+{
+    //Given
+    NSSet* symbolsToRemove = [NSSet setWithObjects:@"*", @"_", nil];
+    NSString* stringToTest = @"The next \\*Test1\\* \\_Test2\\_ should not have backslashes";
+    NSString* stringObjective = @"The next *Test1* _Test2_ should not have backslashes";
+    //When
+    NSString* stringWithRemovedBackslashes = stringWithRemovedBackslashedSymbols(stringToTest, symbolsToRemove);
+    //Then
+    XCTAssertEqualObjects(stringWithRemovedBackslashes, stringObjective);
+}
+
+
 @end


### PR DESCRIPTION
Fixed parsing issue for text blocks that causes that \\* was not recognized as an asterisk on iOS. Added manual validation when the text is not an html.

Sample card payload:
`{
    "type": "AdaptiveCard",
    "version": "1.5",
    "body": [
        {
            "size": "medium",
            "text": "Change Contacts \\*SAMPLE TEXT\\* test",
            "weight": "regular",
            "type": "TextBlock"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
}
`

Before:

![Simulator Screenshot - iPhone 15 - 2024-02-15 at 18 49 21](https://github.com/microsoft/AdaptiveCards-Mobile/assets/130393016/8dfabb22-5655-474f-91be-5240abbcdc3b)

After:

![Simulator Screenshot - iPhone 15 - 2024-02-15 at 18 45 38](https://github.com/microsoft/AdaptiveCards-Mobile/assets/130393016/2a531d53-fb34-4227-b039-0db609a41ab7)
