### PR TITLE
Added default value of AssociatedInput in ChoicesData

### DIFF
--- a/source/shared/cpp/ObjectModel/ChoicesData.cpp
+++ b/source/shared/cpp/ObjectModel/ChoicesData.cpp
@@ -7,7 +7,7 @@
 
 using namespace AdaptiveCards;
 
-ChoicesData::ChoicesData()
+ChoicesData::ChoicesData() : m_associatedInputs(AssociatedInputs::Auto)
 {
 }
 


### PR DESCRIPTION
# Issue
Added default value of AssociatedInput in ChoicesData

# Description
Default value of AssociatedInput in ChoicesData is required. Setting this value to "auto" in the constructor.
