### PR TITLE
Change in resetValue of InputHandler

### DIFF
--- a/samples/v1.5/Scenarios/ValueChangedActionAllInputType.json
+++ b/samples/v1.5/Scenarios/ValueChangedActionAllInputType.json
@@ -1,0 +1,220 @@
+{
+	"$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.0",
+	"body": [
+		{
+			"type": "TextBlock",
+			"size": "medium",
+			"weight": "bolder",
+			"text": "Input.Text elements",
+			"horizontalAlignment": "center"
+		},
+		{
+			"type": "Input.Text",
+			"placeholder": "Name",
+			"style": "text",
+			"maxLength": 0,
+			"id": "SimpleVal",
+			"valueChangedAction": {
+				"type": "Action.ResetInputs",
+				"targetInputIds": [
+					"UrlVal",
+					"EmailVal",
+					"TelVal",
+					"MultiLineVal",
+					"NumVal",
+					"DateVal",
+					"TimeVal",
+					"CompactSelectVal",
+					"SingleSelectVal",
+					"MultiSelectVal",
+					"AcceptsTerms",
+					"ColorPreference"
+				]
+			}
+		},
+		{
+			"type": "Input.Text",
+			"placeholder": "Homepage",
+			"style": "url",
+			"maxLength": 0,
+			"id": "UrlVal"
+		},
+		{
+			"type": "Input.Text",
+			"placeholder": "Email",
+			"style": "email",
+			"maxLength": 0,
+			"id": "EmailVal"
+		},
+		{
+			"type": "Input.Text",
+			"placeholder": "Phone",
+			"style": "tel",
+			"maxLength": 0,
+			"id": "TelVal"
+		},
+		{
+			"type": "Input.Text",
+			"placeholder": "Comments",
+			"style": "text",
+			"isMultiline": true,
+			"maxLength": 0,
+			"id": "MultiLineVal"
+		},
+		{
+			"type": "Input.Number",
+			"placeholder": "Quantity",
+			"min": -5,
+			"max": 5,
+			"value": 1,
+			"id": "NumVal"
+		},
+		{
+			"type": "Input.Date",
+			"placeholder": "Due Date",
+			"id": "DateVal",
+			"value": "2017-09-20"
+		},
+		{
+			"type": "Input.Time",
+			"placeholder": "Start time",
+			"id": "TimeVal",
+			"value": "16:59"
+		},
+		{
+			"type": "TextBlock",
+			"size": "medium",
+			"weight": "bolder",
+			"text": "Input.ChoiceSet",
+			"horizontalAlignment": "center"
+		},
+		{
+			"type": "TextBlock",
+			"text": "What color do you want? (compact)"
+		},
+		{
+			"type": "Input.ChoiceSet",
+			"id": "CompactSelectVal",
+			"style": "compact",
+			"value": "1",
+			"choices": [
+				{
+					"title": "Red",
+					"value": "1"
+				},
+				{
+					"title": "Green",
+					"value": "2"
+				},
+				{
+					"title": "Blue",
+					"value": "3"
+				}
+			]
+		},
+		{
+			"type": "TextBlock",
+			"text": "What color do you want? (expanded)"
+		},
+		{
+			"type": "Input.ChoiceSet",
+			"id": "SingleSelectVal",
+			"style": "expanded",
+			"value": "1",
+			"choices": [
+				{
+					"title": "Red",
+					"value": "1"
+				},
+				{
+					"title": "Green",
+					"value": "2"
+				},
+				{
+					"title": "Blue",
+					"value": "3"
+				}
+			]
+		},
+		{
+			"type": "TextBlock",
+			"text": "What colors do you want? (multiselect)"
+		},
+		{
+			"type": "Input.ChoiceSet",
+			"id": "MultiSelectVal",
+			"style": "expanded",
+			"isMultiSelect": true,
+			"value": "1,3",
+			"choices": [
+				{
+					"title": "Red",
+					"value": "1"
+				},
+				{
+					"title": "Green",
+					"value": "2"
+				},
+				{
+					"title": "Blue",
+					"value": "3"
+				}
+			]
+		},
+		{
+			"type": "TextBlock",
+			"size": "medium",
+			"weight": "bolder",
+			"text": "Input.Toggle",
+			"horizontalAlignment": "center"
+		},
+		{
+			"type": "Input.Toggle",
+			"title": "I accept the terms and conditions (True/False)",
+			"valueOn": "true",
+			"valueOff": "false",
+			"id": "AcceptsTerms"
+		},
+		{
+			"type": "Input.Toggle",
+			"title": "Red cars are better than other cars",
+			"value": "RedCars",
+			"valueOn": "RedCars",
+			"valueOff": "NotRedCars",
+			"id": "ColorPreference"
+		}
+	],
+	"actions": [
+		{
+			"type": "Action.Submit",
+			"title": "Submit",
+			"data": {
+				"id": "1234567890"
+			}
+		},
+		{
+			"type": "Action.ShowCard",
+			"title": "Show Card",
+			"card": {
+				"type": "AdaptiveCard",
+				"body": [
+					{
+						"type": "Input.Text",
+						"placeholder": "enter comment",
+						"style": "text",
+						"maxLength": 0,
+						"id": "CommentVal"
+					}
+				],
+				"actions": [
+					{
+						"type": "Action.Submit",
+						"title": "OK"
+					}
+				]
+			}
+		}
+	]
+}

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/AutoCompleteTextViewHandler.kt
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/AutoCompleteTextViewHandler.kt
@@ -15,7 +15,7 @@ import io.adaptivecards.renderer.RenderedAdaptiveCard
 import io.adaptivecards.renderer.Util
 import io.adaptivecards.renderer.input.customcontrols.ValidatedInputLayout
 
-class AutoCompleteTextViewHandler(baseInputElement: BaseInputElement?,
+class AutoCompleteTextViewHandler(baseInputElement: BaseInputElement,
                                   renderedAdaptiveCard: RenderedAdaptiveCard?, cardId: Long
 ) : BaseInputHandler(baseInputElement, renderedAdaptiveCard, cardId) {
     // For validation visual cues we draw the spinner inside a ValidatedSpinnerLayout so we query for this
@@ -112,5 +112,12 @@ class AutoCompleteTextViewHandler(baseInputElement: BaseInputElement?,
         // Find index for the title
         val index = findTitleIndex(title, choiceInputVector)
         return findStringForIndex(index, choiceInputVector, { choiceInput: ChoiceInput -> choiceInput.GetValue() })
+    }
+
+    override fun getDefaultValue(): String {
+        if (Util.isOfType(m_baseInputElement, ChoiceSetInput::class.java)) {
+            return Util.castTo(m_baseInputElement, ChoiceSetInput::class.java).GetValue()
+        }
+        return super.getDefaultValue()
     }
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/BaseInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/BaseInputHandler.java
@@ -4,6 +4,7 @@ package io.adaptivecards.renderer.inputhandler;
 
 import android.view.View;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import io.adaptivecards.objectmodel.BaseInputElement;
@@ -20,7 +21,7 @@ public abstract class BaseInputHandler implements IInputHandler
         m_inputWatchers = new ArrayList<>();
     }
 
-    public BaseInputHandler(@Nullable BaseInputElement baseInputElement, @Nullable RenderedAdaptiveCard renderedAdaptiveCard, long cardId) {
+    public BaseInputHandler(@NonNull BaseInputElement baseInputElement, @Nullable RenderedAdaptiveCard renderedAdaptiveCard, long cardId) {
         this(baseInputElement);
         m_renderedAdaptiveCard = renderedAdaptiveCard;
         m_cardId = cardId;
@@ -109,8 +110,8 @@ public abstract class BaseInputHandler implements IInputHandler
     }
 
     @Override
-    public void resetValue() {
-    // Default implementation does nothing
+    public String getDefaultValue() {
+        return "";
     }
 
     protected void notifyAllInputWatchers(){
@@ -120,7 +121,7 @@ public abstract class BaseInputHandler implements IInputHandler
         }
     }
 
-    protected BaseInputElement m_baseInputElement = null;
+    protected BaseInputElement m_baseInputElement;
     protected View m_view = null;
     private StretchableInputLayout m_inputLayout = null;
     List<IInputWatcher> m_inputWatchers;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/CheckBoxSetInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/CheckBoxSetInputHandler.java
@@ -60,7 +60,7 @@ public class CheckBoxSetInputHandler extends BaseInputHandler
             return;
         }
 
-        List<String> listValues = Arrays.asList(values.split(";"));
+        List<String> listValues = Arrays.asList(values.split(","));
         for (int i = 0 ; i < choiceInputVector.size(); i++)
         {
             if (listValues.contains(choiceInputVector.get(i).GetValue()))
@@ -94,8 +94,10 @@ public class CheckBoxSetInputHandler extends BaseInputHandler
 
     @Override
     public void resetValue() {
-        ChoiceSetInput choiceSetInput = Util.castTo(m_baseInputElement, ChoiceSetInput.class);
-        setInput(choiceSetInput.GetValue());
+        if (Util.isOfType(m_baseInputElement, ChoiceSetInput.class)) {
+            ChoiceSetInput choiceSetInput = Util.castTo(m_baseInputElement, ChoiceSetInput.class);
+            setInput(choiceSetInput.GetValue());
+        }
     }
 
     private List<CheckBox> m_checkBoxList;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/CheckBoxSetInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/CheckBoxSetInputHandler.java
@@ -93,11 +93,11 @@ public class CheckBoxSetInputHandler extends BaseInputHandler
     }
 
     @Override
-    public void resetValue() {
+    public String getDefaultValue() {
         if (Util.isOfType(m_baseInputElement, ChoiceSetInput.class)) {
-            ChoiceSetInput choiceSetInput = Util.castTo(m_baseInputElement, ChoiceSetInput.class);
-            setInput(choiceSetInput.GetValue());
+            return Util.castTo(m_baseInputElement, ChoiceSetInput.class).GetValue();
         }
+        return super.getDefaultValue();
     }
 
     private List<CheckBox> m_checkBoxList;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ComboBoxInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ComboBoxInputHandler.java
@@ -88,8 +88,10 @@ public class ComboBoxInputHandler extends BaseInputHandler
 
     @Override
     public void resetValue() {
-        ChoiceSetInput choiceSetInput = Util.castTo(m_baseInputElement, ChoiceSetInput.class);
-        setInput(choiceSetInput.GetValue());
+        if(Util.isOfType(m_baseInputElement, ChoiceSetInput.class)) {
+            ChoiceSetInput choiceSetInput = Util.castTo(m_baseInputElement, ChoiceSetInput.class);
+            setInput(choiceSetInput.GetValue());
+        }
     }
 
     @Override

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ComboBoxInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ComboBoxInputHandler.java
@@ -87,11 +87,11 @@ public class ComboBoxInputHandler extends BaseInputHandler
     }
 
     @Override
-    public void resetValue() {
-        if(Util.isOfType(m_baseInputElement, ChoiceSetInput.class)) {
-            ChoiceSetInput choiceSetInput = Util.castTo(m_baseInputElement, ChoiceSetInput.class);
-            setInput(choiceSetInput.GetValue());
+    public String getDefaultValue() {
+        if (Util.isOfType(m_baseInputElement, ChoiceSetInput.class)) {
+            return Util.castTo(m_baseInputElement, ChoiceSetInput.class).GetValue();
         }
+        return super.getDefaultValue();
     }
 
     @Override

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/DateInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/DateInputHandler.java
@@ -122,10 +122,11 @@ public class DateInputHandler extends TextInputHandler
     }
 
     @Override
-    public void resetValue() {
+    public String getDefaultValue() {
         if (Util.isOfType(m_baseInputElement, DateInput.class)) {
-            setInput(Util.castTo(m_baseInputElement, DateInput.class).GetValue());
+            return Util.castTo(m_baseInputElement, DateInput.class).GetValue();
         }
+        return super.getDefaultValue();
     }
 
     private FragmentManager m_fragmentManager;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/DateInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/DateInputHandler.java
@@ -121,6 +121,13 @@ public class DateInputHandler extends TextInputHandler
         return (beforeYear < afterYear || beforeOrSameMonthOfTheSameYear);
     }
 
+    @Override
+    public void resetValue() {
+        if (Util.isOfType(m_baseInputElement, DateInput.class)) {
+            setInput(Util.castTo(m_baseInputElement, DateInput.class).GetValue());
+        }
+    }
+
     private FragmentManager m_fragmentManager;
 
     public static final String DATE_FORMAT = "yyyy-MM-dd";

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/IInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/IInputHandler.java
@@ -58,7 +58,7 @@ public interface IInputHandler
     void registerInputObserver();
 
     /**
-     * reset value of the input field to default.
+     * default value for the input filed
      */
-    void resetValue();
+    String getDefaultValue();
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/NumberInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/NumberInputHandler.java
@@ -72,10 +72,10 @@ public class NumberInputHandler extends TextInputHandler
     }
 
     @Override
-    public void resetValue() {
+    public String getDefaultValue() {
         if (Util.isOfType(m_baseInputElement, NumberInput.class)) {
-            setInput(String.valueOf(Util.castTo(m_baseInputElement, NumberInput.class).GetValue()));
+            return String.valueOf(Util.castTo(m_baseInputElement, NumberInput.class).GetValue());
         }
+        return super.getDefaultValue();
     }
-
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/NumberInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/NumberInputHandler.java
@@ -71,4 +71,11 @@ public class NumberInputHandler extends TextInputHandler
         return isValid;
     }
 
+    @Override
+    public void resetValue() {
+        if (Util.isOfType(m_baseInputElement, NumberInput.class)) {
+            setInput(String.valueOf(Util.castTo(m_baseInputElement, NumberInput.class).GetValue()));
+        }
+    }
+
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/RadioGroupInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/RadioGroupInputHandler.java
@@ -78,8 +78,10 @@ public class RadioGroupInputHandler extends BaseInputHandler
 
     @Override
     public void resetValue() {
-        ChoiceSetInput choiceSetInput = Util.castTo(m_baseInputElement, ChoiceSetInput.class);
-        setInput(choiceSetInput.GetValue());
+        if (Util.isOfType(m_baseInputElement, ChoiceSetInput.class)) {
+            ChoiceSetInput choiceSetInput = Util.castTo(m_baseInputElement, ChoiceSetInput.class);
+            setInput(choiceSetInput.GetValue());
+        }
     }
 
     @Override

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/RadioGroupInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/RadioGroupInputHandler.java
@@ -77,11 +77,11 @@ public class RadioGroupInputHandler extends BaseInputHandler
     }
 
     @Override
-    public void resetValue() {
+    public String getDefaultValue() {
         if (Util.isOfType(m_baseInputElement, ChoiceSetInput.class)) {
-            ChoiceSetInput choiceSetInput = Util.castTo(m_baseInputElement, ChoiceSetInput.class);
-            setInput(choiceSetInput.GetValue());
+            return Util.castTo(m_baseInputElement, ChoiceSetInput.class).GetValue();
         }
+        return super.getDefaultValue();
     }
 
     @Override

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/RatingInputHandler.kt
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/RatingInputHandler.kt
@@ -51,11 +51,13 @@ class RatingInputHandler(
         return isValid
     }
 
-    override fun resetValue() {
+
+    override fun getDefaultValue(): String {
         if (Util.isOfType(m_baseInputElement, RatingInput::class.java)) {
             val ratingInput = Util.castTo(m_baseInputElement, RatingInput::class.java)
-            input = ratingInput.GetValue().toString()
+            return ratingInput.GetValue().toString()
         }
+        return super.getDefaultValue()
     }
 
     override fun registerInputObserver() {

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/RatingInputHandler.kt
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/RatingInputHandler.kt
@@ -52,8 +52,10 @@ class RatingInputHandler(
     }
 
     override fun resetValue() {
-        val ratingInput = Util.castTo(m_baseInputElement, RatingInput::class.java)
-        input = ratingInput.GetValue().toString()
+        if (Util.isOfType(m_baseInputElement, RatingInput::class.java)) {
+            val ratingInput = Util.castTo(m_baseInputElement, RatingInput::class.java)
+            input = ratingInput.GetValue().toString()
+        }
     }
 
     override fun registerInputObserver() {

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/TextInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/TextInputHandler.java
@@ -3,7 +3,6 @@
 package io.adaptivecards.renderer.inputhandler;
 
 import android.text.Editable;
-import android.text.TextWatcher;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.EditText;
 
@@ -80,8 +79,9 @@ public class TextInputHandler extends BaseInputHandler
 
     @Override
     public void resetValue() {
-        TextInput textInput = Util.castTo(m_baseInputElement, TextInput.class);
-        setInput(textInput.GetValue());
+        if (Util.isOfType(m_baseInputElement, TextInput.class)) {
+            setInput(Util.castTo(m_baseInputElement, TextInput.class).GetValue());
+        }
     }
 
     public void setFocusToView()

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/TextInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/TextInputHandler.java
@@ -78,10 +78,11 @@ public class TextInputHandler extends BaseInputHandler
     }
 
     @Override
-    public void resetValue() {
+    public String getDefaultValue() {
         if (Util.isOfType(m_baseInputElement, TextInput.class)) {
-            setInput(Util.castTo(m_baseInputElement, TextInput.class).GetValue());
+            return Util.castTo(m_baseInputElement, TextInput.class).GetValue();
         }
+        return super.getDefaultValue();
     }
 
     public void setFocusToView()

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/TimeInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/TimeInputHandler.java
@@ -150,6 +150,13 @@ public class TimeInputHandler extends TextInputHandler
         return (beforeHour < afterHour || (beforeHour == afterHour && beforeMinute <= afterMinute));
     }
 
+    @Override
+    public void resetValue() {
+        if (Util.isOfType(m_baseInputElement, TimeInput.class)) {
+            setInput(Util.castTo(m_baseInputElement, TimeInput.class).GetValue());
+        }
+    }
+
     private FragmentManager m_fragmentManager;
 
     public static final String TIME_FORMAT_SUBMIT = "kk:mm";

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/TimeInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/TimeInputHandler.java
@@ -151,10 +151,11 @@ public class TimeInputHandler extends TextInputHandler
     }
 
     @Override
-    public void resetValue() {
+    public String getDefaultValue() {
         if (Util.isOfType(m_baseInputElement, TimeInput.class)) {
-            setInput(Util.castTo(m_baseInputElement, TimeInput.class).GetValue());
+            return Util.castTo(m_baseInputElement, TimeInput.class).GetValue();
         }
+        return super.getDefaultValue();
     }
 
     private FragmentManager m_fragmentManager;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ToggleInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ToggleInputHandler.java
@@ -68,11 +68,11 @@ public class ToggleInputHandler extends BaseInputHandler
     }
 
     @Override
-    public void resetValue() {
+    public String getDefaultValue() {
         if (Util.isOfType(m_baseInputElement, ToggleInput.class)) {
-            ToggleInput toggleInput = Util.castTo(m_baseInputElement, ToggleInput.class);
-            setInput(toggleInput.GetValue());
+            return Util.castTo(m_baseInputElement, ToggleInput.class).GetValue();
         }
+        return super.getDefaultValue();
     }
 
     @Override

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ToggleInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ToggleInputHandler.java
@@ -69,8 +69,10 @@ public class ToggleInputHandler extends BaseInputHandler
 
     @Override
     public void resetValue() {
-        ToggleInput toggleInput = Util.castTo(m_baseInputElement, ToggleInput.class);
-        setInput(toggleInput.GetValue());
+        if (Util.isOfType(m_baseInputElement, ToggleInput.class)) {
+            ToggleInput toggleInput = Util.castTo(m_baseInputElement, ToggleInput.class);
+            setInput(toggleInput.GetValue());
+        }
     }
 
     @Override

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ValueChangedActionInputWatcher.kt
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ValueChangedActionInputWatcher.kt
@@ -27,7 +27,7 @@ class ValueChangedActionInputWatcher(
             val targetInputIds = valueChangedAction.GetTargetInputIds()
             renderedCard.getInputsHandlerFromCardId(cardId)?.let{
                 for (targetInputId in targetInputIds) {
-                    it[targetInputId]?.resetValue()
+                    it[targetInputId]?.input = it[targetInputId]?.getDefaultValue()
                 }
             }
         }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ValueChangedActionInputWatcher.kt
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ValueChangedActionInputWatcher.kt
@@ -25,9 +25,11 @@ class ValueChangedActionInputWatcher(
     override fun onInputChange(id: String?, value: String?) {
         if(valueChangedAction.GetValueChangedActionType() == ValueChangedActionType.ResetInputs) {
             val targetInputIds = valueChangedAction.GetTargetInputIds()
-            renderedCard.getInputsHandlerFromCardId(cardId)?.let{
+            renderedCard.getInputsHandlerFromCardId(cardId)?.let{ it ->
                 for (targetInputId in targetInputIds) {
-                    it[targetInputId]?.input = it[targetInputId]?.getDefaultValue()
+                    it[targetInputId]?.let { inputHandler ->
+                        inputHandler.input = inputHandler.getDefaultValue()
+                    }
                 }
             }
         }

--- a/source/android/mobile/src/main/res/raw/importer_card.json
+++ b/source/android/mobile/src/main/res/raw/importer_card.json
@@ -59,6 +59,10 @@
 										"title": "ValueChangedAction",
 										"value": "v1.5/Scenarios/ValueChangedAction.json"
 									},
+									{
+										"title": "ValueChangedActionAllInputType",
+										"value": "v1.5/Scenarios/ValueChangedActionAllInputType.json"
+									},
                                     {
                                         "title": "Inputs",
                                         "value": "v1.5/Scenarios/InputsWithValidation.json"


### PR DESCRIPTION
# Description

TimeInputHandler, DateInputHandler and NumberInputHandler extends from TextInputHandler.
resetValue called on these inputHandler results in crash because  the base implementation in TextInputHandler cast the element to TextInput.

- Removed `resetValue` from `IInputHandler`
- Added `getDefaultValue()` in `IInputHandler`
- BaseInputHandler return empty String in `getDefaultValue()`
- Other InputHandler return their own default value in `getDefaultValue()`



# Sample Card
Added new json - ValueChangedActionAllInputType.json
[resetValue.webm](https://github.com/microsoft/AdaptiveCards-Mobile/assets/68814139/84a6686f-40a2-4019-8e9f-4f815ea47aa4)

---

[valueChange.webm](https://github.com/microsoft/AdaptiveCards-Mobile/assets/68814139/85d5cd66-fe8c-4e98-8a38-6040e300f4ac)

