### PR TITLE
Conditional Enabled button fix for not getting Input Text callbacks

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRDateTextField.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRDateTextField.mm
@@ -164,6 +164,9 @@ using namespace AdaptiveCards;
     [self endEditing:YES];
     self.text = [_decodeFormatter stringFromDate:[self getCurrentDate]];
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self);
+    for(CompletionHandler completion in _completionHandlers) {
+        completion();
+    }
 }
 
 - (IBAction)update:(UIDatePicker *)picker

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextInputHandler.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextInputHandler.mm
@@ -31,6 +31,7 @@
         self.hasValidationProperties = self.isRequired || self.maxLength || self.regexPredicate;
         self.text = [NSString stringWithCString:inputBlock->GetValue().c_str() encoding:NSUTF8StringEncoding];
         self.defaultValue = self.text;
+        self._completionHandlers = [[NSMutableArray alloc] init];
         if (self.text && self.text.length) {
             self.hasText = YES;
         }
@@ -137,6 +138,7 @@
         self.hasMax = maxVal.has_value();
         self.max = maxVal.value_or(0);
         self.hasValidationProperties = self.isRequired || self.hasMin || self.hasMax;
+        self._completionHandlers = [[NSMutableArray alloc] init];
     }
     return self;
 }


### PR DESCRIPTION
# Related Issue
 We did some refactoring in Conditional Enablement of submit and execute button and now we are not getting callback for Input type text and number. The issue was in ACRTextInputHandler, _completionHandler was not initialised and hence we were not getting callback. Fixed this for both input types, also fixed am minor issue in ACRDateTextField where date gets selected on dismissing the picker and callback should happen for this too.