### PR TITLE
Reseting number input to default value for value changed action

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextInputHandler.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextInputHandler.mm
@@ -122,6 +122,7 @@
         self.isRequired = numberInputBlock->GetIsRequired();
         auto value = numberInputBlock->GetValue();
         self.text = (value.has_value()) ? [[NSNumber numberWithDouble:value.value_or(0)] stringValue] : nil;
+        self.defaultValue = self.text;
         self.hasText = self.text != nil;
 
         NSMutableCharacterSet *characterSets = [NSMutableCharacterSet characterSetWithCharactersInString:@"-."];


### PR DESCRIPTION
# Related Issue

Input type number was not getting reset to its default value if it part of valuechangedAction field of any other input type. The reason was that default value was not set, setting that in this PR.