### PR TITLE
Enabling pod integration from branch or tag

### DIFF
--- a/AdaptiveCards.podspec
+++ b/AdaptiveCards.podspec
@@ -1,0 +1,1 @@
+./source/ios/tools/AdaptiveCards.podspec


### PR DESCRIPTION
# Changes
In this PR, we are putting symlink for podspec in root folder. This will enable cocoapod integration from a branch or tag. 
We should be able to use pod directly from branch like this:
```
pod 'AdaptiveCards/AdaptiveCardsCore', :git => 'https://github.com/microsoft/AdaptiveCards-Mobile', :branch => 'BRANCH_NAME'
pod 'AdaptiveCards/AdaptiveCardsPrivate', :git => 'https://github.com/microsoft/AdaptiveCards-Mobile', :branch => 'BRANCH_NAME'
pod 'AdaptiveCards/ObjectModel', :git => 'https://github.com/microsoft/AdaptiveCards-Mobile', :branch => 'BRANCH_NAME'
```

# How Verified
Ran sample app pod dependency to a branch. 
