### PR TITLE
Mengli/bugfix

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -92,7 +92,7 @@ public class ActionElementRenderer extends BaseActionElementRenderer
                 else
                 {
                     Button button = new Button(context);
-                    button.setTextColor(getColor(hostConfig.GetForegroundColor(ContainerStyle.Default, ForegroundColor.Attention, false)));
+                    button.getBackground().setColorFilter(getColor(hostConfig.GetForegroundColor(ContainerStyle.Default, ForegroundColor.Attention, false)), PorterDuff.Mode.MULTIPLY);
                     return button;
                 }
             }


### PR DESCRIPTION
# Related Issue

This PR is to fix [this issue](https://github.com/microsoft/AdaptiveCards-Mobile/issues/96)


# Description
For ActionElementRenderer.java, when the Button style is "Destructive", the Button background color is not matching with web client SDK. In this sample JSON, the "Reject" button color is one has "Destructive" style.
Web client:
![Screenshot 2024-07-24 at 4 08 35 PM](https://github.com/user-attachments/assets/ce517bc5-47dd-4484-a614-5dddf7960bb2)
Mobile client 
|before Fix | After Fix|
| :---: | :---: |
| ![Screenshot 2024-07-24 at 5 31 29 PM](https://github.com/user-attachments/assets/c7ce3efa-9b88-429b-9e0a-2637d050fedc)| ![Screenshot 2024-07-24 at 4 08 40 PM](https://github.com/user-attachments/assets/7ef64ffa-672f-49b9-9d3a-1ea5952d0756)|

