### PR TITLE
[iOS] add line break support for windows style

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -743,7 +743,12 @@ void buildIntermediateResultForText(ACRView *rootView, ACOHostConfig *hostConfig
     NSString *parsedString = (markDownParser->HasHtmlTags()) ? [NSString stringWithCString:markdownString.c_str() encoding:NSUTF8StringEncoding] : [NSString stringWithCString:markDownParser->GetRawText().c_str() encoding:NSUTF8StringEncoding];
 
     if (markDownParser->HasHtmlTags() && ([parsedString containsString:@"\n"] || [parsedString containsString:@"\r"])) {
-        parsedString = [parsedString stringByReplacingOccurrencesOfString:@"[\\n\\r]"
+        // Different systems have different line break styles
+        // Windows style: \r\n
+        // Modern mac style: \n
+        // Old mac style: \r
+        NSString *replacementPattern = [parsedString containsString:@"\r\n"] ? @"\r\n" : @"[\\n\\r]";
+        parsedString = [parsedString stringByReplacingOccurrencesOfString:replacementPattern
                                                                withString:@"<br>"
                                                                   options:NSRegularExpressionSearch
                                                                     range:NSMakeRange(0, [parsedString length])];


### PR DESCRIPTION
# Description

Cards that used windows style line break was adding two `<br>` tags for each \r\n instead of a single `<br>`.

# Sample Card

`{
  "type": "AdaptiveCard",
  "version": "1.4",
  "body": [
    {
      "type": "TextBlock",
      "weight": "bolder",
      "text": "**line1**\r\n\r\nline2\r\n\r\nline3",
      "wrap": true
    }
  ]
}`

# How Verified

|                | Before | After     |
| -------- | ------- | ------- |
| \r\n |  ![image](https://github.com/user-attachments/assets/782c8220-a5d3-457d-b07c-db07d300ab24) | ![image](https://github.com/user-attachments/assets/ce94b92e-53d7-40b3-abe9-9374e6ee8f11) |
| \n |    ![image](https://github.com/user-attachments/assets/ce94b92e-53d7-40b3-abe9-9374e6ee8f11)  | ![image](https://github.com/user-attachments/assets/ce94b92e-53d7-40b3-abe9-9374e6ee8f11) |
| \r    |  ![image](https://github.com/user-attachments/assets/ce94b92e-53d7-40b3-abe9-9374e6ee8f11) | ![image](https://github.com/user-attachments/assets/ce94b92e-53d7-40b3-abe9-9374e6ee8f11) |

