### PR TITLE
[Android] Fix module syntax in Settings.gradle

### DIFF
--- a/source/android/settings.gradle
+++ b/source/android/settings.gradle
@@ -1,1 +1,1 @@
-include ':mobilechatapp', ':uitestapp', ':mobile', ':adaptivecards', 'adaptivecardsnew'
+include ':mobilechatapp', ':uitestapp', ':mobile', ':adaptivecards', ':adaptivecardsnew'


### PR DESCRIPTION
Fixed module syntax in Settings.gradle