### PR TITLE
fix: objc2 friendly nullability annotations to ACOAdaptiveCard.h

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -410,7 +410,7 @@
 		CFF95C0F2982E4EC00F321C3 /* ACOTypeaheadDebouncerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CFF95C0E2982E4EC00F321C3 /* ACOTypeaheadDebouncerTests.mm */; };
 		DD278A02932F65F8BDD1EA5D /* Pods_AdaptiveCards.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 255F5D3143215497D4067E21 /* Pods_AdaptiveCards.framework */; };
 		E67241702E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.m in Sources */ = {isa = PBXBuildFile; fileRef = E672416F2E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.m */; };
-		E67241712E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.h in Headers */ = {isa = PBXBuildFile; fileRef = E672416E2E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.h */; };
+		E67241712E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.h in Headers */ = {isa = PBXBuildFile; fileRef = E672416E2E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EC367F912F6036B68C5BBFDB /* Pods_AdaptiveCards_AdaptiveCardsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3DBB3CD3C02321AED9AEF65 /* Pods_AdaptiveCards_AdaptiveCardsTests.framework */; };
 		F401A8781F0DB69B006D7AF2 /* ACRImageSetUICollectionView.mm in Sources */ = {isa = PBXBuildFile; fileRef = F401A8761F0DB69B006D7AF2 /* ACRImageSetUICollectionView.mm */; };
 		F401A87C1F0DCBC8006D7AF2 /* ACRImageSetRenderer.mm in Sources */ = {isa = PBXBuildFile; fileRef = F401A87A1F0DCBC8006D7AF2 /* ACRImageSetRenderer.mm */; };
@@ -626,7 +626,7 @@
 		FA7F19222E884BB10052B2C6 /* BuiltInFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7F19082E884BB10052B2C6 /* BuiltInFunctions.swift */; };
 		FA7F19232E884BB10052B2C6 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7F190A2E884BB10052B2C6 /* Expression.swift */; };
 		FA7F19252E884D7D0052B2C6 /* TSExpressionObjCBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7F19242E884D7D0052B2C6 /* TSExpressionObjCBridge.m */; };
-		FA7F19272E884DD60052B2C6 /* TSExpressionObjCBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = FA7F19262E884DD60052B2C6 /* TSExpressionObjCBridge.h */; };
+		FA7F19272E884DD60052B2C6 /* TSExpressionObjCBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = FA7F19262E884DD60052B2C6 /* TSExpressionObjCBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.h
@@ -26,19 +26,19 @@
 
 @interface ACOAdaptiveCard : NSObject
 
-@property ACORefresh *refresh;
-@property ACOAuthentication *authentication;
+@property (nullable, nonatomic, strong) ACORefresh *refresh;
+@property (nullable, nonatomic, strong) ACOAuthentication *authentication;
 
-+ (ACOAdaptiveCardParseResult *)fromJson:(NSString *)payload;
-- (NSData *)inputs;
-- (NSArray<ACRIBaseInputHandler> *)getInputs;
-- (void)setInputs:(NSArray *)inputs;
-- (void)appendInputs:(NSArray *)inputs;
-- (NSArray<ACORemoteResourceInformation *> *)remoteResourceInformation;
-- (NSData *)additionalProperty;
++ (nonnull ACOAdaptiveCardParseResult *)fromJson:(nullable NSString *)payload;
+- (nullable NSData *)inputs;
+- (nullable NSArray<ACRIBaseInputHandler> *)getInputs;
+- (void)setInputs:(nonnull NSArray *)inputs;
+- (void)appendInputs:(nonnull NSArray *)inputs;
+- (nullable NSArray<ACORemoteResourceInformation *> *)remoteResourceInformation;
+- (nullable NSData *)additionalProperty;
 
 /// Swift Adaptive Card Bridge Layer
-- (SwiftAdaptiveCardParseResult *)swiftParseResult;
+- (nullable SwiftAdaptiveCardParseResult *)swiftParseResult;
 + (BOOL)isSwiftParserEnabled;
 + (void)setSwiftParserEnabled:(BOOL)enabled;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/AdaptiveCards.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/AdaptiveCards.h
@@ -78,6 +78,8 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import "ACRTextView.h"
 #import "ACRToggleInputView.h"
 #import "ACRView.h"
+#import "ACRStringBasedKeyValueObservation.h"
+#import "TSExpressionObjCBridge.h"
 #else
 /// Cocoapods Imports
 #import <AdaptiveCards/ACOActionOverflow.h>
@@ -143,5 +145,7 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import <AdaptiveCards/ACRTextView.h>
 #import <AdaptiveCards/ACRToggleInputView.h>
 #import <AdaptiveCards/ACRView.h>
+#import <AdaptiveCards/ACRStringBasedKeyValueObservation.h>
+#import <AdaptiveCards/TSExpressionObjCBridge.h>
 
 #endif


### PR DESCRIPTION
# Related Issue

# Description

This PR applies Objective-C 2.0 nullability annotations to improve Swift interoperability and type safety in the AdaptiveCards iOS SDK. The changes include:

## Changes Made

### 1. **ACOAdaptiveCard.h - Nullability Annotations**
   - Added `nullable` and `nonnull` annotations to all properties and method signatures
   - Properties annotated:
     - `@property (nullable, nonatomic, strong) ACORefresh *refresh;`
     - `@property (nullable, nonatomic, strong) ACOAuthentication *authentication;`
   - Methods annotated with explicit nullability:
     - `+ (nonnull ACOAdaptiveCardParseResult *)fromJson:(nullable NSString *)payload;`
     - `- (nullable NSData *)inputs;`
     - `- (nullable NSArray<ACRIBaseInputHandler> *)getInputs;`
     - `- (void)setInputs:(nonnull NSArray *)inputs;`
     - `- (void)appendInputs:(nonnull NSArray *)inputs;`
     - `- (nullable NSArray<ACORemoteResourceInformation *> *)remoteResourceInformation;`
     - `- (nullable NSData *)additionalProperty;`
     - `- (nullable SwiftAdaptiveCardParseResult *)swiftParseResult;`

### 2. **AdaptiveCards.h - Public Header Exports**
   - Added missing public header imports for newly exposed APIs:
     - `#import "ACRStringBasedKeyValueObservation.h"`
     - `#import "TSExpressionObjCBridge.h"`
   - Ensures these headers are available to SDK consumers

### 3. **project.pbxproj - Header Visibility**
   - Updated build settings for two headers to be `Public`:
     - `ACRStringBasedKeyValueObservation.h` - Changed from default to `Public`
     - `TSExpressionObjCBridge.h` - Changed from default to `Public`
   - Allows these headers to be imported by SDK consumers

## Benefits

- **Improved Swift Interoperability**: Swift code can now understand which parameters/return values can be nil
- **Better Type Safety**: Compiler warnings when nil is passed where nonnull is expected
- **Clearer API Contract**: Developers know which parameters are required vs optional
- **Future-Proof**: Prepares codebase for modern Objective-C best practices

# Sample Card

N/A - These are API-level changes that don't affect card rendering behavior.

# How Verified

1. **Build Verification**: 
   - Verified SDK builds successfully with nullability annotations
   - No compiler warnings introduced by the changes
   
2. **Manual Testing**:
   - Confirmed existing functionality remains unchanged
   - Verified headers are properly exported in both SPM and CocoaPods configurations
   
3. **Swift Integration Test**:
   - Tested Swift code can properly access annotated APIs
   - Verified optional/non-optional types are correctly inferred in Swift

All existing tests pass without modification, confirming backward compatibility.