### PR TITLE
Minor Improvements for Integration

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/RenderedAdaptiveCard.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/RenderedAdaptiveCard.java
@@ -18,6 +18,7 @@ import io.adaptivecards.objectmodel.AdaptiveCard;
 import io.adaptivecards.objectmodel.ACTheme;
 import io.adaptivecards.renderer.inputhandler.BaseInputHandler;
 import io.adaptivecards.renderer.inputhandler.IInputHandler;
+import io.adaptivecards.renderer.registration.FeatureFlagResolverUtility;
 
 public class RenderedAdaptiveCard {
 
@@ -273,8 +274,8 @@ public class RenderedAdaptiveCard {
     }
 
     @NonNull
-    public String replaceStringResources(@NonNull String input) {
-        if (AdaptiveCard.IsStringResourcePresent(input)) {
+    public String checkAndReplaceStringResources(@NonNull String input) {
+        if (FeatureFlagResolverUtility.isStringResourceEnabled() && AdaptiveCard.IsStringResourcePresent(input)) {
             return AdaptiveCard.ReplaceStringResources(input, getAdaptiveCard().GetResources(), getLanguageTag());
         }
         return input;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/InputUtils.kt
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/InputUtils.kt
@@ -13,10 +13,18 @@ object InputUtils {
 
     @JvmStatic
     fun appendRequiredLabelSuffix(
-        paragraph: SpannableStringBuilder,
+        input: CharSequence,
+        label: String?,
         hostConfig: HostConfig,
         renderArgs: RenderArgs
     ): SpannableStringBuilder {
+
+        val paragraph = SpannableStringBuilder(input)
+
+        if (label.isNullOrEmpty() || !TextInput.getIsRequired(label)) {
+            return paragraph
+        }
+
         val inputLabelConfig = hostConfig.GetInputs().label.requiredInputs
         val spanStart = paragraph.length
         var requiredLabelSuffix = inputLabelConfig.suffix

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/RichTextBlockRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/RichTextBlockRenderer.java
@@ -48,7 +48,6 @@ import io.adaptivecards.renderer.TagContent;
 import io.adaptivecards.renderer.Util;
 import io.adaptivecards.renderer.actionhandler.ICardActionHandler;
 import io.adaptivecards.renderer.input.InputUtils;
-import io.adaptivecards.renderer.registration.FeatureFlagResolverUtility;
 
 public class RichTextBlockRenderer extends BaseCardElementRenderer
 {
@@ -145,9 +144,9 @@ public class RichTextBlockRenderer extends BaseCardElementRenderer
                 DateTimeParser parser = new DateTimeParser(textRun.GetLanguage());
                 String formattedText = parser.GenerateString(textRun.GetTextForDateParsing());
 
-                if (FeatureFlagResolverUtility.isStringResourceEnabled()) {
-                    formattedText = renderedCard.replaceStringResources(formattedText);
-                }
+                // Check & replace string resource if present
+                formattedText = renderedCard.checkAndReplaceStringResources(formattedText);
+
 
                 paragraph.append(formattedText);
 
@@ -200,9 +199,7 @@ public class RichTextBlockRenderer extends BaseCardElementRenderer
             }
         }
 
-        if (TextInput.getIsRequired(richTextBlock.GetLabelFor())) {
-            paragraph = InputUtils.appendRequiredLabelSuffix(paragraph, hostConfig, renderArgs);
-        }
+        paragraph = InputUtils.appendRequiredLabelSuffix(paragraph, richTextBlock.GetLabelFor(), hostConfig, renderArgs);
 
         return paragraph;
     }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/TextBlockRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/TextBlockRenderer.java
@@ -299,19 +299,14 @@ public class TextBlockRenderer extends BaseCardElementRenderer
         DateTimeParser parser = new DateTimeParser(textBlock.GetLanguage());
         String textWithFormattedDates = parser.GenerateString(textBlock.GetTextForDateParsing());
 
-        if (FeatureFlagResolverUtility.isStringResourceEnabled()) {
-            textWithFormattedDates = renderedCard.replaceStringResources(textWithFormattedDates);
-        }
+        // Check & replace string resource if present
+        textWithFormattedDates = renderedCard.checkAndReplaceStringResources(textWithFormattedDates);
 
         RendererUtil.SpecialTextHandleResult textHandleResult = RendererUtil.handleSpecialTextAndQueryLinks(textWithFormattedDates);
         CharSequence htmlString = textHandleResult.getHtmlString();
+        htmlString = InputUtils.appendRequiredLabelSuffix(htmlString, textBlock.GetLabelFor(), hostConfig, renderArgs);
 
-        if (TextInput.getIsRequired(textBlock.GetLabelFor())) {
-            textView.setText(InputUtils.appendRequiredLabelSuffix(new SpannableStringBuilder(htmlString), hostConfig, renderArgs));
-        } else {
-            textView.setText(htmlString);
-        }
-
+        textView.setText(htmlString);
         textView.setEllipsize(TextUtils.TruncateAt.END);
         textView.setOnTouchListener(new TouchTextView(new SpannableString(htmlString)));
 


### PR DESCRIPTION
This pull request refactors how string resources and required input labels are handled in the Android Adaptive Cards renderer. The main improvements include centralizing the logic for checking and replacing string resources, streamlining the required label suffix application, and simplifying method signatures for better maintainability.

**String Resource Handling:**
* Introduced a new method `checkAndReplaceStringResources` in `RenderedAdaptiveCard`, which now checks the feature flag before replacing string resources, consolidating the logic previously scattered across multiple renderers.
* Updated `RichTextBlockRenderer` and `TextBlockRenderer` to use the new `checkAndReplaceStringResources` method, removing redundant feature flag checks and ensuring consistent behavior. [[1]](diffhunk://#diff-010fa4db2c725f9715a8c97221e1ca3ad2533bc510d8b32b0ae83ad7c2efad3aL148-R149) [[2]](diffhunk://#diff-e4c286d6f2d1ffd59a9c10f4840120c4f82e390e617bce9c254188659ed7d389L302-L314)

**Required Label Suffix Handling:**
* Refactored `InputUtils.appendRequiredLabelSuffix` to accept an input string and label, instead of a `SpannableStringBuilder`, simplifying its usage and making it easier to append the required label suffix only when necessary.
* Updated usages in `RichTextBlockRenderer` and `TextBlockRenderer` to leverage the new `appendRequiredLabelSuffix` signature, removing manual checks for required labels and streamlining the rendering code. [[1]](diffhunk://#diff-010fa4db2c725f9715a8c97221e1ca3ad2533bc510d8b32b0ae83ad7c2efad3aL203-R202) [[2]](diffhunk://#diff-e4c286d6f2d1ffd59a9c10f4840120c4f82e390e617bce9c254188659ed7d389L302-L314)

**Code Cleanup:**
* Removed unnecessary imports of `FeatureFlagResolverUtility` from files where string resource handling is now delegated to `RenderedAdaptiveCard`.