### PR TITLE
[iOS] Citations - Fixed text block attachment tap no-op issue by passing ActActionDelegate

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCitationManager.m
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCitationManager.m
@@ -156,6 +156,7 @@ static NSString *const referencesKey = @"References";
     ACRRenderResult *renderResult = [ACRRenderer render:acoCard
                                                  config:self.rootView.hostConfig
                                         widthConstraint:config.referenceWindowSize.width - (2 * config.contentPadding)
+                                               delegate:self.rootView.acrActionDelegate
                                                   theme:citation.theme];
         
     


### PR DESCRIPTION
# Related Issue
When implemented Citations feature we observed that once the more details bottom sheet is opened, the subsequent taps to text block citations stopped working. 

This was caused by rootView object getting re-created but without actionDelegate. 
I passed the ACRActionDelegate to solve this issue.
