### PR TITLE
Fixed popover visibility when keyboard is popped

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBottomSheetPresentationController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBottomSheetPresentationController.mm
@@ -26,9 +26,9 @@
     CGFloat containerHeight = self.containerView.bounds.size.height;
     CGFloat visibleHeight = containerHeight - self.keyboardHeight;
     CGFloat y = visibleHeight - targetHeight;
-    y = y < 0 ? 0 : y;
-
-    return CGRectMake(0, y, self.containerView.bounds.size.width, targetHeight);
+    CGFloat safeY = self.presentingViewController.view.safeAreaInsets.top;
+    y = y <= 0 ? safeY : y;
+    return CGRectMake(0, y, self.containerView.bounds.size.width, visibleHeight - y);
 }
 
 #pragma mark - Layout
@@ -108,8 +108,8 @@
     self.isAdjustingForKeyboard = YES;
 
     CGRect newFrame = [self frameOfPresentedViewInContainerView];
-
-    [UIView animateWithDuration:0.25 animations:^{
+    NSTimeInterval animationDuration = [notification.userInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+    [UIView animateWithDuration:animationDuration animations:^{
         self.presentedView.frame = newFrame;
     } completion:^(BOOL finished) {
         self.isAdjustingForKeyboard = NO;
@@ -122,8 +122,8 @@
     self.isAdjustingForKeyboard = YES;
 
     CGRect newFrame = [self frameOfPresentedViewInContainerView];
-
-    [UIView animateWithDuration:0.25 animations:^{
+    NSTimeInterval animationDuration = [notification.userInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+    [UIView animateWithDuration:animationDuration animations:^{
         self.presentedView.frame = newFrame;
     } completion:^(BOOL finished) {
         self.isAdjustingForKeyboard = NO;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBottomSheetViewController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBottomSheetViewController.mm
@@ -189,6 +189,7 @@
     UIScrollView *scrollView = [[UIScrollView alloc] init];
     scrollView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addSubview:scrollView];
+    scrollView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
     self.scrollView = scrollView;
     self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.scrollView addSubview:self.contentView];


### PR DESCRIPTION
Issue:
<img width="206" height="1622" alt="image" src="https://github.com/user-attachments/assets/ad048d78-8673-4061-be87-41b37770caa8" />

Fix:
<img width="206" height="1622" alt="image" src="https://github.com/user-attachments/assets/450c5a94-0f89-4391-bdb8-7a13e5bca508" />
