### PR TITLE
Fix: TalkBack does not announce Image role on ImageView

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
@@ -22,6 +22,10 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.constraintlayout.widget.ConstraintSet;
 import androidx.fragment.app.FragmentManager;
 
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
+import androidx.core.view.AccessibilityDelegateCompat;
+
 import io.adaptivecards.R;
 import io.adaptivecards.objectmodel.BaseCardElement;
 import io.adaptivecards.objectmodel.HeightType;
@@ -330,6 +334,15 @@ public class ImageRenderer extends BaseCardElementRenderer
 
         ImageView imageView = new ImageView(context);
         imageView.setContentDescription(image.GetAltText());
+
+        // Fix: Set Image role for TalkBack (#490, #375)
+        ViewCompat.setAccessibilityDelegate(imageView, new AccessibilityDelegateCompat() {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
+                super.onInitializeAccessibilityNodeInfo(host, info);
+                info.setRoleDescription("Image");
+            }
+        });
 
         int backgroundColor = getBackgroundColorFromHexCode(image.GetBackgroundColor());
 


### PR DESCRIPTION
## Problem
TalkBack does not announce the "Image" role when focusing on ImageView elements in Adaptive Cards, making it difficult for visually impaired users to understand the content type.

## Solution
Added an AccessibilityDelegate to ImageView in ImageRenderer.java that sets roleDescription="Image" so TalkBack announces the element as an image.

## Changes
- **ImageRenderer.java**: Added AccessibilityDelegate with roleDescription "Image" on the ImageView

## Testing
- Verified with TalkBack on Android that images are now announced as "Image" role
- No impact on visual rendering