### PR TITLE
Fix: TalkBack announces both Link and Button roles for OpenUrl actions

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -15,6 +15,9 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 
 import androidx.appcompat.widget.TooltipCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
+import androidx.core.view.AccessibilityDelegateCompat;
 import androidx.fragment.app.FragmentManager;
 
 import io.adaptivecards.R;
@@ -172,7 +175,17 @@ public class ActionElementRenderer extends BaseActionElementRenderer
         }
 
         if (baseActionElement.GetElementType() == ActionType.OpenUrl) {
-            button.setContentDescription(Util.getOpenUrlAnnouncement(context, baseActionElement.GetTitle()));
+            // Fix: Use roleDescription instead of appending "link" to contentDescription (#492)
+            // This prevents TalkBack from announcing both "link" (from text) and "Button" (from widget)
+            button.setContentDescription(baseActionElement.GetTitle());
+            ViewCompat.setAccessibilityDelegate(button, new AccessibilityDelegateCompat() {
+                @Override
+                public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
+                    super.onInitializeAccessibilityNodeInfo(host, info);
+                    info.setClassName("");
+                    info.setRoleDescription("Link");
+                }
+            });
         }
 
         viewGroup.addView(button);


### PR DESCRIPTION
## Problem
When TalkBack focuses on an OpenUrl action element, it announces both "Link" and "Button" roles, creating a confusing experience for screen reader users.

## Solution
Set roleDescription="Link" and clear the Button className on OpenUrl action elements so TalkBack only announces the "Link" role.

## Changes
- **ActionElementRenderer.java**: Added roleDescription "Link" and cleared Button className for OpenUrl actions

## Testing
- Verified with TalkBack on Android that OpenUrl actions announce only "Link" role
- Other action types (Submit, Execute) remain unaffected