### PR TITLE
Fix: TalkBack announces incorrect item count for dropdown (includes hidden placeholder)

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
@@ -308,7 +308,8 @@ public class ChoiceSetInputRenderer extends BaseCardElementRenderer
                 View spinnerView = super.getDropDownView(position, convertView, parent);
                 TextView spinnerTextView = (TextView) spinnerView;
 
-                String talkbackAnnouncement = context.getResources().getString(R.string.spinner_talkback_announcement, m_items.get(position), position+1, m_items.size());
+                // Fix: Use getCount() instead of m_items.size() to exclude hidden placeholder (#466)
+                String talkbackAnnouncement = context.getResources().getString(R.string.spinner_talkback_announcement, m_items.get(position), position+1, getCount());
                 spinnerTextView.setContentDescription(talkbackAnnouncement);
                 return spinnerView;
             }


### PR DESCRIPTION
## Problem
TalkBack announces an incorrect item count for dropdown/choice-set spinners because it counts the hidden placeholder item that is not visible to the user.

## Solution
Changed from m_items.size() to getCount() which returns the adapter count excluding the hidden placeholder item.

## Changes
- **ChoiceSetInputRenderer.java**: Changed item count from m_items.size() to getCount()

## Testing
- Verified with TalkBack on Android that the correct item count is announced
- Placeholder item is properly excluded from the count