### PR TITLE
fix(android): prevent TalkBack from focusing on hidden/GONE elements

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseCardElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseCardElementRenderer.java
@@ -277,6 +277,13 @@ public abstract class BaseCardElementRenderer implements IBaseCardElementRendere
         }
 
         elementView.setVisibility(visibility);
+
+        // When hiding an element, also mark it as not important for accessibility
+        // so TalkBack does not focus on invisible/gone views (#12, #108).
+        // Restore importance when showing the element again.
+        elementView.setImportantForAccessibility(
+            isVisible ? View.IMPORTANT_FOR_ACCESSIBILITY_AUTO
+                      : View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
     }
 
     /**


### PR DESCRIPTION
fix(android): prevent TalkBack from focusing on hidden/GONE elements

## Problem
TalkBack focus can navigate to elements that are visually hidden (`View.GONE`), announcing their content even though they are not visible on screen. For example:
- After "Tue, May 20, 2017 12:25PM" text, TalkBack moves to a hidden element and announces "departs from" (#12)
- After "AMS" text, TalkBack focuses on a hidden element instead of "San Francisco" (#108)

## Root Cause
`BaseCardElementRenderer.setVisibility()` correctly sets `View.GONE` on hidden elements, but does not update their accessibility importance. Android's `View.GONE` hides the view visually but does not guarantee TalkBack will skip it.

## Fix
In `setVisibility()`, after setting the visibility, also update `importantForAccessibility`:
- **Hiding**: Set to `IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS` to ensure TalkBack completely skips the element and all its children
- **Showing**: Restore to `IMPORTANT_FOR_ACCESSIBILITY_AUTO` so TalkBack can access the element normally

## Testing
- Navigate Flight Itinerary card with TalkBack — no hidden "departs from" element should receive focus
- Navigate Flight Update card — after "AMS", focus should move to "San Francisco", not a hidden element

Fixes #12, #108
