### PR TITLE
[Release] AdaptiveCards iOS SDK v2.11.17

### DIFF
--- a/source/ios/tools/AdaptiveCards.podspec
+++ b/source/ios/tools/AdaptiveCards.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'AdaptiveCards'
 
-  spec.version          = '2.11.7'
+  spec.version          = '2.11.17'
 
   spec.license          = { :type => 'Adaptive Cards Binary EULA', :file => 'source/EULA-Non-Windows.txt' } 
 
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
 
   spec.summary          = 'Adaptive Cards are a new way for developers to exchange card content in a common and consistent way'
   
-  spec.source       = { :git => 'https://github.com/microsoft/AdaptiveCards-Mobile.git', :tag => 'iOS/adaptivecards-ios@2.11.7' }
+  spec.source       = { :git => 'https://github.com/microsoft/AdaptiveCards-Mobile.git', :tag => 'iOS/adaptivecards-ios@2.11.17' }
 
   spec.default_subspecs = 'AdaptiveCardsCore', 'AdaptiveCardsPrivate', 'ObjectModel', 'UIProviders'
 


### PR DESCRIPTION
## Release v2.11.17 (iOS only)

### Version bump
- iOS podspec: 2.11.7 -> 2.11.17

This is a version bump to include all accumulated fixes on main since v2.11.7.