### PR TITLE
Fix visionOS build: guard keyboardDismissMode with #if !TARGET_OS_VISION

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBottomSheetViewController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBottomSheetViewController.mm
@@ -189,7 +189,9 @@
     UIScrollView *scrollView = [[UIScrollView alloc] init];
     scrollView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addSubview:scrollView];
+#if !TARGET_OS_VISION
     scrollView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
+#endif
     self.scrollView = scrollView;
     self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.scrollView addSubview:self.contentView];


### PR DESCRIPTION
## Summary
`keyboardDismissMode` is `API_UNAVAILABLE(visionOS)`. Building AdaptiveCards for `xros` fails at `ACRBottomSheetViewController.mm:192`.

## Fix

## Impact
- Enables visionOS archive builds for AdaptiveCards
- No behavioral change on iOS (guard is only for visionOS target)