### PR TITLE
fix: scope ToggleVisibility stack reset to toggle actions only

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOVisibilityManager.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOVisibilityManager.mm
@@ -185,59 +185,6 @@
 /// to fully discard these constraints. addArrangedSubview: then re-adds the
 /// view to the hierarchy and the arranged list in one step.
 ///
-/// Why removeFromSuperview is safe:
-/// - Views are immediately re-added via addArrangedSubview: in the same
-///   synchronous call, so they're never missing from the hierarchy for
-///   more than a single statement.
-/// - Gesture recognizers are owned by the view object (strong reference),
-///   not the superview — they survive the remove/re-add round-trip.
-/// - Accessibility state is retained because UIAccessibility properties
-///   are stored on the view, not on the parent relationship.
-/// - No constraint scanning, removal, or copying occurs.
-/// - The operation is idempotent — repeated cycles produce identical results.
-///
-/// Guard: Only triggers when a visible column has broken layout (width < 1
-/// or positioned off-screen). No-op for cards where layout is already correct.
-- (void)resetStackViewLayoutForView:(UIView *)viewToBeUnhidden
-                           hostView:(ACRContentStackView *)hostView
-{
-    if (!hostView || !viewToBeUnhidden)
-    {
-        return;
-    }
-
-    // Check if the unhidden view actually needs layout repair
-    BOOL needsFix = (viewToBeUnhidden.frame.size.width < 1.0 ||
-                     viewToBeUnhidden.frame.origin.x >= hostView.frame.size.width);
-    if (!needsFix)
-    {
-        return;
-    }
-
-    // Get all arranged subviews via public API
-    NSArray<UIView *> *arranged = [hostView getArrangedSubviews];
-    if (!arranged || arranged.count == 0)
-    {
-        return;
-    }
-
-    // Full reset: remove all, then re-add in same order.
-    // removeFromSuperview is essential — without it, UIStackView retains
-    // stale internal UISV-spacing constraints from the initial hidden layout.
-    NSArray<UIView *> *snapshot = [arranged copy];
-    for (UIView *view in snapshot)
-    {
-        [hostView removeArrangedSubview:view];
-        [view removeFromSuperview];
-    }
-    for (UIView *view in snapshot)
-    {
-        [hostView addArrangedSubview:view];
-    }
-
-    [hostView setNeedsLayout];
-}
-
 /// unhide `viewToBeUnhidden`. `hostView` is a superview of type ColumnView or ColumnSetView
 - (void)unhideView:(UIView *)viewToBeUnhidden hostView:(ACRContentStackView *)hostView
 {
@@ -264,7 +211,6 @@
         if (viewToBeUnhidden.isHidden) {
             viewToBeUnhidden.hidden = NO;
             [hostView increaseIntrinsicContentSize:viewToBeUnhidden];
-            [self resetStackViewLayoutForView:viewToBeUnhidden hostView:hostView];
         }
 
         // previous head view's separator becomes visible
@@ -276,7 +222,6 @@
         if (viewToBeUnhidden.isHidden) {
             viewToBeUnhidden.hidden = NO;
             [hostView increaseIntrinsicContentSize:viewToBeUnhidden];
-            [self resetStackViewLayoutForView:viewToBeUnhidden hostView:hostView];
         }
         [self changeVisiblityOfAssociatedViews:viewToBeUnhidden visibilityValue:NO contentStackView:hostView];
     }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRToggleVisibilityTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRToggleVisibilityTarget.mm
@@ -9,6 +9,7 @@
 #import "ACOBaseActionElementPrivate.h"
 #import "ACOHostConfigPrivate.h"
 #import "ACOVisibilityManager.h"
+#import "ACRContentStackView.h"
 #import "ACRRendererPrivate.h"
 #import "ACRView.h"
 #import "BaseActionElement.h"
@@ -104,6 +105,64 @@
 
     for (id<ACOIVisibilityManagerFacade> viewToUpdateVisibility in facades) {
         [viewToUpdateVisibility updatePaddingVisibility];
+    }
+
+    // Repair stack layout for any host whose columns were just unhidden.
+    //
+    // Context: UIStackView retains stale internal UISV-spacing constraints when
+    // a column is initially hidden and later unhidden via ToggleVisibility. The
+    // fix is a full reset: remove all arranged subviews (with removeFromSuperview
+    // to discard stale constraints), then re-add them in original order.
+    //
+    // This MUST run here in doSelectActionWithAction: (toggle-only context),
+    // NOT in unhideView: which also fires during initial card rendering. At
+    // initial render time views have zero frames, so the needsFix guard falsely
+    // triggers and corrupts layout (e.g. WorkDay card buttons disappear).
+    //
+    // Safety notes:
+    // - removeFromSuperview is safe: views are re-added synchronously in the
+    //   same call, gesture recognizers survive (strong ref on view), and
+    //   accessibility properties are stored on the view, not the parent.
+    // - The operation is idempotent — repeated toggle cycles produce identical
+    //   results.
+    for (id<ACOIVisibilityManagerFacade> facade in facades) {
+        if (![facade isKindOfClass:[ACRContentStackView class]]) {
+            continue;
+        }
+
+        ACRContentStackView *hostView = (ACRContentStackView *)facade;
+        if (hostView.frame.size.width < 1.0) {
+            continue; // Host not yet laid out — skip to avoid false positives
+        }
+
+        NSArray<UIView *> *arranged = [hostView getArrangedSubviews];
+        if (!arranged || arranged.count == 0) {
+            continue;
+        }
+
+        // Check if any visible column has broken layout (zero width or off-screen)
+        BOOL needsFix = NO;
+        for (UIView *v in arranged) {
+            if (!v.isHidden && (v.frame.size.width < 1.0 ||
+                v.frame.origin.x >= hostView.frame.size.width)) {
+                needsFix = YES;
+                break;
+            }
+        }
+        if (!needsFix) {
+            continue;
+        }
+
+        // Full reset: remove all, then re-add in same order.
+        NSArray<UIView *> *snapshot = [arranged copy];
+        for (UIView *v in snapshot) {
+            [hostView removeArrangedSubview:v];
+            [v removeFromSuperview];
+        }
+        for (UIView *v in snapshot) {
+            [hostView addArrangedSubview:v];
+        }
+        [hostView setNeedsLayout];
     }
 
     // Post accessibility notification so VoiceOver announces the layout change


### PR DESCRIPTION
## Problem

`resetStackViewLayoutForView:hostView:` was called from `unhideView:hostView:` in `ACOVisibilityManager`, which fires during **all** unhide operations — including initial card rendering. At initial render time, views have zero frames (pre-layout), so the `needsFix` guard falsely triggers and the full stack reset corrupts layout for cards that render visible columns on first load.

## Fix

Move the stack layout reset from `unhideView:` to `doSelectActionWithAction:` in `ACRToggleVisibilityTarget`. This scopes it to **user-initiated ToggleVisibility actions only** — the only context where the UIStackView constraint repair is actually needed.

### Why this is better
- **Correct scope**: `unhideView:` is a general-purpose method called during both initial rendering and toggle actions. The stack reset is only needed after toggle cycles, not during initial layout.
- **No false positives**: During initial render, views have zero frames. The `needsFix` guard (`width < 1.0`) incorrectly triggers on these pre-layout views, causing unnecessary and destructive resets.
- **Single responsibility**: `doSelectActionWithAction:` is the entry point for all ToggleVisibility user actions. Placing the repair here keeps it tightly scoped to the code path that causes the stale-constraint issue.

### Changes
- **ACOVisibilityManager.mm**: Remove unused `resetStackViewLayoutForView:hostView:` method and its 2 call sites from `unhideView:`
- **ACRToggleVisibilityTarget.mm**: Add the stack reset loop after all toggles complete in `doSelectActionWithAction:`, with full documentation and guards

### Guards
- `isKindOfClass:` check before cast
- Host frame width > 0 check (skip hosts not yet laid out)
- Nil/empty arranged subviews check
- `needsFix` scan: only triggers if a visible column has zero width or is positioned off-screen
- Idempotent: repeated toggle cycles produce identical results

## Validation

- ToggleVisibility cards: columns re-layout correctly after toggle ✅
- Non-toggle cards: render correctly on initial load ✅
- Backwards compatible: no-op for cards without ToggleVisibility actions