### PR TITLE
revert: remove ios26 toggle-visibility bug fixes and version bumps

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOVisibilityManager.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOVisibilityManager.mm
@@ -185,6 +185,59 @@
 /// to fully discard these constraints. addArrangedSubview: then re-adds the
 /// view to the hierarchy and the arranged list in one step.
 ///
+/// Why removeFromSuperview is safe:
+/// - Views are immediately re-added via addArrangedSubview: in the same
+///   synchronous call, so they're never missing from the hierarchy for
+///   more than a single statement.
+/// - Gesture recognizers are owned by the view object (strong reference),
+///   not the superview — they survive the remove/re-add round-trip.
+/// - Accessibility state is retained because UIAccessibility properties
+///   are stored on the view, not on the parent relationship.
+/// - No constraint scanning, removal, or copying occurs.
+/// - The operation is idempotent — repeated cycles produce identical results.
+///
+/// Guard: Only triggers when a visible column has broken layout (width < 1
+/// or positioned off-screen). No-op for cards where layout is already correct.
+- (void)resetStackViewLayoutForView:(UIView *)viewToBeUnhidden
+                           hostView:(ACRContentStackView *)hostView
+{
+    if (!hostView || !viewToBeUnhidden)
+    {
+        return;
+    }
+
+    // Check if the unhidden view actually needs layout repair
+    BOOL needsFix = (viewToBeUnhidden.frame.size.width < 1.0 ||
+                     viewToBeUnhidden.frame.origin.x >= hostView.frame.size.width);
+    if (!needsFix)
+    {
+        return;
+    }
+
+    // Get all arranged subviews via public API
+    NSArray<UIView *> *arranged = [hostView getArrangedSubviews];
+    if (!arranged || arranged.count == 0)
+    {
+        return;
+    }
+
+    // Full reset: remove all, then re-add in same order.
+    // removeFromSuperview is essential — without it, UIStackView retains
+    // stale internal UISV-spacing constraints from the initial hidden layout.
+    NSArray<UIView *> *snapshot = [arranged copy];
+    for (UIView *view in snapshot)
+    {
+        [hostView removeArrangedSubview:view];
+        [view removeFromSuperview];
+    }
+    for (UIView *view in snapshot)
+    {
+        [hostView addArrangedSubview:view];
+    }
+
+    [hostView setNeedsLayout];
+}
+
 /// unhide `viewToBeUnhidden`. `hostView` is a superview of type ColumnView or ColumnSetView
 - (void)unhideView:(UIView *)viewToBeUnhidden hostView:(ACRContentStackView *)hostView
 {
@@ -211,6 +264,7 @@
         if (viewToBeUnhidden.isHidden) {
             viewToBeUnhidden.hidden = NO;
             [hostView increaseIntrinsicContentSize:viewToBeUnhidden];
+            [self resetStackViewLayoutForView:viewToBeUnhidden hostView:hostView];
         }
 
         // previous head view's separator becomes visible
@@ -222,6 +276,7 @@
         if (viewToBeUnhidden.isHidden) {
             viewToBeUnhidden.hidden = NO;
             [hostView increaseIntrinsicContentSize:viewToBeUnhidden];
+            [self resetStackViewLayoutForView:viewToBeUnhidden hostView:hostView];
         }
         [self changeVisiblityOfAssociatedViews:viewToBeUnhidden visibilityValue:NO contentStackView:hostView];
     }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOVisibilityManager.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOVisibilityManager.mm
@@ -168,76 +168,6 @@
     }
 }
 
-/// Reset UIStackView's internal layout for a view that was initially hidden
-/// (isVisible: false). UIStackView assigns stale zero-width internal sizing to
-/// views added while hidden. After unhiding via ToggleVisibility, this stale
-/// sizing leaves the column at the wrong position or width.
-///
-/// Fix: Remove ALL arranged subviews from the host's UIStackView and re-add
-/// them in the same order. This forces UIStackView to fully discard its stale
-/// internal constraints (UISV-spacing, UISV-alignment) and rebuild them from
-/// scratch, giving every column proper layout.
-///
-/// Why full reset instead of single-view re-insert:
-/// UIStackView retains stale internal constraints for views that are only
-/// removed from the arranged list (removeArrangedSubview:) but remain in
-/// the view hierarchy. removeFromSuperview is required to force UIStackView
-/// to fully discard these constraints. addArrangedSubview: then re-adds the
-/// view to the hierarchy and the arranged list in one step.
-///
-/// Why removeFromSuperview is safe:
-/// - Views are immediately re-added via addArrangedSubview: in the same
-///   synchronous call, so they're never missing from the hierarchy for
-///   more than a single statement.
-/// - Gesture recognizers are owned by the view object (strong reference),
-///   not the superview — they survive the remove/re-add round-trip.
-/// - Accessibility state is retained because UIAccessibility properties
-///   are stored on the view, not on the parent relationship.
-/// - No constraint scanning, removal, or copying occurs.
-/// - The operation is idempotent — repeated cycles produce identical results.
-///
-/// Guard: Only triggers when a visible column has broken layout (width < 1
-/// or positioned off-screen). No-op for cards where layout is already correct.
-- (void)resetStackViewLayoutForView:(UIView *)viewToBeUnhidden
-                           hostView:(ACRContentStackView *)hostView
-{
-    if (!hostView || !viewToBeUnhidden)
-    {
-        return;
-    }
-
-    // Check if the unhidden view actually needs layout repair
-    BOOL needsFix = (viewToBeUnhidden.frame.size.width < 1.0 ||
-                     viewToBeUnhidden.frame.origin.x >= hostView.frame.size.width);
-    if (!needsFix)
-    {
-        return;
-    }
-
-    // Get all arranged subviews via public API
-    NSArray<UIView *> *arranged = [hostView getArrangedSubviews];
-    if (!arranged || arranged.count == 0)
-    {
-        return;
-    }
-
-    // Full reset: remove all, then re-add in same order.
-    // removeFromSuperview is essential — without it, UIStackView retains
-    // stale internal UISV-spacing constraints from the initial hidden layout.
-    NSArray<UIView *> *snapshot = [arranged copy];
-    for (UIView *view in snapshot)
-    {
-        [hostView removeArrangedSubview:view];
-        [view removeFromSuperview];
-    }
-    for (UIView *view in snapshot)
-    {
-        [hostView addArrangedSubview:view];
-    }
-
-    [hostView setNeedsLayout];
-}
-
 /// unhide `viewToBeUnhidden`. `hostView` is a superview of type ColumnView or ColumnSetView
 - (void)unhideView:(UIView *)viewToBeUnhidden hostView:(ACRContentStackView *)hostView
 {
@@ -264,7 +194,6 @@
         if (viewToBeUnhidden.isHidden) {
             viewToBeUnhidden.hidden = NO;
             [hostView increaseIntrinsicContentSize:viewToBeUnhidden];
-            [self resetStackViewLayoutForView:viewToBeUnhidden hostView:hostView];
         }
 
         // previous head view's separator becomes visible
@@ -276,7 +205,6 @@
         if (viewToBeUnhidden.isHidden) {
             viewToBeUnhidden.hidden = NO;
             [hostView increaseIntrinsicContentSize:viewToBeUnhidden];
-            [self resetStackViewLayoutForView:viewToBeUnhidden hostView:hostView];
         }
         [self changeVisiblityOfAssociatedViews:viewToBeUnhidden visibilityValue:NO contentStackView:hostView];
     }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.h
@@ -43,10 +43,6 @@
 
 - (void)addArrangedSubview:(nonnull UIView *)view;
 
-- (void)removeArrangedSubview:(nonnull UIView *)view;
-
-- (void)insertArrangedSubview:(nonnull UIView *)view atIndex:(NSUInteger)index;
-
 - (void)config:(nullable NSDictionary<NSString *, id> *)attributes;
 
 - (void)adjustHuggingForLastElement;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
@@ -24,7 +24,6 @@ using namespace AdaptiveCards;
     NSMutableSet *_invisibleViews;
     ACRVerticalContentAlignment _verticalContentAlignment;
     ACRHorizontalAlignment _horizontalAlignment;
-    NSTimeInterval _lastSelectActionTouchTimestamp;
 }
 
 // this is the dedicated initializer
@@ -542,25 +541,10 @@ using namespace AdaptiveCards;
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
     if (self.selectActionTarget) {
-        // Guard: iOS 26 re-delivers touchesEnded with the same touch timestamp
-        // but a different UIEvent pointer ~350ms later. Block the re-delivery.
-        UITouch *touch = [touches anyObject];
-        NSTimeInterval touchTS = touch ? touch.timestamp : 0;
-        if (_lastSelectActionTouchTimestamp > 0 &&
-            fabs(touchTS - _lastSelectActionTouchTimestamp) < 0.001) {
-            return; // Same touch — iOS 26 re-delivery, block it
-        }
-        _lastSelectActionTouchTimestamp = touchTS;
         [self.selectActionTarget doSelectAction];
     } else {
         [self.nextResponder touchesEnded:touches withEvent:event];
     }
-}
-
-- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
-{
-    _lastSelectActionTouchTimestamp = 0;
-    [self.nextResponder touchesCancelled:touches withEvent:event];
 }
 
 - (UIView *)addPaddingSpace
@@ -757,13 +741,6 @@ using namespace AdaptiveCards;
 {
     if (view) {
         [_stackView insertArrangedSubview:view atIndex:insertionIndex];
-    }
-}
-
-- (void)removeArrangedSubview:(UIView *)view
-{
-    if (view) {
-        [_stackView removeArrangedSubview:view];
     }
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRToggleVisibilityTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRToggleVisibilityTarget.mm
@@ -9,7 +9,6 @@
 #import "ACOBaseActionElementPrivate.h"
 #import "ACOHostConfigPrivate.h"
 #import "ACOVisibilityManager.h"
-#import "ACRContentStackView.h"
 #import "ACRRendererPrivate.h"
 #import "ACRView.h"
 #import "BaseActionElement.h"
@@ -105,64 +104,6 @@
 
     for (id<ACOIVisibilityManagerFacade> viewToUpdateVisibility in facades) {
         [viewToUpdateVisibility updatePaddingVisibility];
-    }
-
-    // Repair stack layout for any host whose columns were just unhidden.
-    //
-    // Context: UIStackView retains stale internal UISV-spacing constraints when
-    // a column is initially hidden and later unhidden via ToggleVisibility. The
-    // fix is a full reset: remove all arranged subviews (with removeFromSuperview
-    // to discard stale constraints), then re-add them in original order.
-    //
-    // This MUST run here in doSelectActionWithAction: (toggle-only context),
-    // NOT in unhideView: which also fires during initial card rendering. At
-    // initial render time views have zero frames, so the needsFix guard falsely
-    // triggers and corrupts layout (e.g. WorkDay card buttons disappear).
-    //
-    // Safety notes:
-    // - removeFromSuperview is safe: views are re-added synchronously in the
-    //   same call, gesture recognizers survive (strong ref on view), and
-    //   accessibility properties are stored on the view, not the parent.
-    // - The operation is idempotent — repeated toggle cycles produce identical
-    //   results.
-    for (id<ACOIVisibilityManagerFacade> facade in facades) {
-        if (![facade isKindOfClass:[ACRContentStackView class]]) {
-            continue;
-        }
-
-        ACRContentStackView *hostView = (ACRContentStackView *)facade;
-        if (hostView.frame.size.width < 1.0) {
-            continue; // Host not yet laid out — skip to avoid false positives
-        }
-
-        NSArray<UIView *> *arranged = [hostView getArrangedSubviews];
-        if (!arranged || arranged.count == 0) {
-            continue;
-        }
-
-        // Check if any visible column has broken layout (zero width or off-screen)
-        BOOL needsFix = NO;
-        for (UIView *v in arranged) {
-            if (!v.isHidden && (v.frame.size.width < 1.0 ||
-                v.frame.origin.x >= hostView.frame.size.width)) {
-                needsFix = YES;
-                break;
-            }
-        }
-        if (!needsFix) {
-            continue;
-        }
-
-        // Full reset: remove all, then re-add in same order.
-        NSArray<UIView *> *snapshot = [arranged copy];
-        for (UIView *v in snapshot) {
-            [hostView removeArrangedSubview:v];
-            [v removeFromSuperview];
-        }
-        for (UIView *v in snapshot) {
-            [hostView addArrangedSubview:v];
-        }
-        [hostView setNeedsLayout];
     }
 
     // Post accessibility notification so VoiceOver announces the layout change

--- a/source/ios/tools/AdaptiveCards.podspec
+++ b/source/ios/tools/AdaptiveCards.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'AdaptiveCards'
 
-  spec.version          = '2.11.8'
+  spec.version          = '2.11.7'
 
   spec.license          = { :type => 'Adaptive Cards Binary EULA', :file => 'source/EULA-Non-Windows.txt' } 
 
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
 
   spec.summary          = 'Adaptive Cards are a new way for developers to exchange card content in a common and consistent way'
   
-  spec.source       = { :git => 'https://github.com/microsoft/AdaptiveCards-Mobile.git', :tag => 'iOS/adaptivecards-ios@2.11.8' }
+  spec.source       = { :git => 'https://github.com/microsoft/AdaptiveCards-Mobile.git', :tag => 'iOS/adaptivecards-ios@2.11.7' }
 
   spec.default_subspecs = 'AdaptiveCardsCore', 'AdaptiveCardsPrivate', 'ObjectModel', 'UIProviders'
 

--- a/source/ios/tools/AdaptiveCards.podspec
+++ b/source/ios/tools/AdaptiveCards.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'AdaptiveCards'
 
-  spec.version          = '2.11.7'
+  spec.version          = '2.11.6'
 
   spec.license          = { :type => 'Adaptive Cards Binary EULA', :file => 'source/EULA-Non-Windows.txt' } 
 
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
 
   spec.summary          = 'Adaptive Cards are a new way for developers to exchange card content in a common and consistent way'
   
-  spec.source       = { :git => 'https://github.com/microsoft/AdaptiveCards-Mobile.git', :tag => 'iOS/adaptivecards-ios@2.11.7' }
+  spec.source       = { :git => 'https://github.com/microsoft/AdaptiveCards-Mobile.git', :tag => 'iOS/adaptivecards-ios@2.11.6' }
 
   spec.default_subspecs = 'AdaptiveCardsCore', 'AdaptiveCardsPrivate', 'ObjectModel', 'UIProviders'
 

--- a/source/ios/tools/AdaptiveCards.podspec
+++ b/source/ios/tools/AdaptiveCards.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'AdaptiveCards'
 
-  spec.version          = '2.11.6'
+  spec.version          = '2.11.5'
 
   spec.license          = { :type => 'Adaptive Cards Binary EULA', :file => 'source/EULA-Non-Windows.txt' } 
 
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
 
   spec.summary          = 'Adaptive Cards are a new way for developers to exchange card content in a common and consistent way'
   
-  spec.source       = { :git => 'https://github.com/microsoft/AdaptiveCards-Mobile.git', :tag => 'iOS/adaptivecards-ios@2.11.6' }
+  spec.source       = { :git => 'https://github.com/microsoft/AdaptiveCards-Mobile.git', :tag => 'iOS/adaptivecards-ios@2.11.5' }
 
   spec.default_subspecs = 'AdaptiveCardsCore', 'AdaptiveCardsPrivate', 'ObjectModel', 'UIProviders'
 


### PR DESCRIPTION
## Summary

This PR reverts 5 merged PRs that introduced and attempted to fix a regression bug (B2) in the iOS 26 toggle-visibility flow. The reverts are applied cleanest-first (newest → oldest) with zero conflicts.

## Motivation

- **#671** `fix/ios26-toggle-visibility-touch-redelivery` introduced a regression (B2) while fixing an earlier bug.
- **#678** `fix/ios26-toggle-visibility-scope-reset` attempted to fix B2 but did not fully resolve it.
- **#673, #674, #676** are version bump PRs that were stacked on top of the above and are no longer relevant to ship.

The goal is to restore `main` to the state of **#668** (`gauravkeshre/feature/citation/webrendering`) so that feature can be deployed cleanly without carrying the unresolved regression.

## Reverts (in order applied)

| # | PR | Branch |
|---|----|--------|
| 1 | #678 | `fix/ios26-toggle-visibility-scope-reset` |
| 2 | #676 | `users/pharika/version2.11.8` |
| 3 | #674 | `users/hggzm/version-bump-2.11.7` |
| 4 | #671 | `fix/ios26-toggle-visibility-touch-redelivery` |
| 5 | #673 | `feature/pharika/v2.11.6` |

## Post-merge state

After merging, `main` HEAD will effectively be at **#668** (`gauravkeshre/feature/citation/webrendering` — Apr 3), with all prior history intact.

## Testing
- No functional code changes — pure reverts.
- Verify the toggle-visibility regression (B2) is no longer reproducible after merge.