### PR TITLE
[ios][fix] Reverted a change that was causing regression and failing ST

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
@@ -910,12 +910,6 @@ using namespace AdaptiveCards;
 
     if (!acoElem.element->GetIsVisible()) {
         [self registerInvisibleView:renderedView];
-    } else if ([renderedView isKindOfClass:[ACRContentStackView class]] &&
-               !((ACRContentStackView *)renderedView).hasVisibleContent) {
-        // The element is marked visible, but all of its children are invisible.
-        // Register it the same way as an explicit isVisible:false so the view
-        // and its separator are collapsed by applyVisibilityToSubviews.
-        [self registerInvisibleView:renderedView];
     }
 }
 


### PR DESCRIPTION
# Related Issue

Elements marked visible with all children marked iinvisible were treated as invisible. 
This was causing ST failure.

Reverted the check in ACRContentStackView