### PR TITLE
fix(ios): surface text input placeholder as VoiceOver accessibility hint

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
@@ -81,6 +81,13 @@
                                               encoding:NSUTF8StringEncoding];
     txtInput.text = [NSString stringWithCString:inputBlock->GetValue().c_str() encoding:NSUTF8StringEncoding];
 
+    // Surface the placeholder text as a VoiceOver accessibility hint so it is
+    // announced even after the user begins typing (UITextField stops reading
+    // the visual placeholder once `text` becomes non-empty).
+    if (txtInput.placeholder.length > 0) {
+        txtInput.accessibilityHint = txtInput.placeholder;
+    }
+
     txtInput.allowsEditingTextAttributes = YES;
     return txtInput;
 }


### PR DESCRIPTION
## Description

Surfaces the text input `placeholder` as the VoiceOver `accessibilityHint` for
all `ACRTextField` variants (text, email, tel, url, password). On iOS, `UITextField`
only reads the visual placeholder while the value is empty — once the user
starts typing (or focus moves away), the placeholder is no longer announced and
the field becomes effectively unlabeled to VoiceOver users when there is no
explicit `Input.Text.label`.

Setting `accessibilityHint` keeps the placeholder text discoverable through
the standard VoiceOver hint rotor and announcement.

## Files Changed

- `source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm`

## Behavior

- If `placeholder` is empty, no hint is set (existing behavior unchanged).
- If `placeholder` is non-empty, it becomes the `accessibilityHint` on the
  configured text field instance (also covers `ACRTextEmailField`,
  `ACRTextTelelphoneField`, `ACRTextUrlField`, password mode).
- Renderer-level change only — no model/object-model changes, no public API
  surface change.

## Validation

- Builds clean for iOS (CI: `teams-adaptivecards-ios-pr`).
- VoiceOver behavior: `Input.Text` with placeholder "your name" now announces
  "your name" as a hint after focus, not just before first keystroke.

## Severity

Sev3 — site walkthrough audit.
