### PR TITLE
fix(ios): scale text input fonts with Dynamic Type

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextField.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextField.mm
@@ -42,9 +42,12 @@
     // Set natural text alignment
     self.textAlignment = NSTextAlignmentNatural;
 
-    // Setup font and minimum font size
-    self.font = [UIFont systemFontOfSize:15];
+    // Setup font and minimum font size — scale with Dynamic Type so users
+    // who increase Larger Text accessibility setting get a proportionally
+    // larger input font.
+    self.font = [[UIFontMetrics defaultMetrics] scaledFontForFont:[UIFont systemFontOfSize:15]];
     self.minimumFontSize = 15;
+    self.adjustsFontForContentSizeCategory = YES;
 
     // Display clear button always
     self.clearButtonMode = UITextFieldViewModeAlways;
@@ -109,8 +112,9 @@
     // Set the minimum font size.
     self.minimumFontSize = 17;
 
-    // Set the font (system, size 14).
-    self.font = [UIFont systemFontOfSize:14];
+    // Set the font (system, size 14) — scale with Dynamic Type.
+    self.font = [[UIFontMetrics defaultMetrics] scaledFontForFont:[UIFont systemFontOfSize:14]];
+    self.adjustsFontForContentSizeCategory = YES;
 
     // Setup text input traits: email keyboard and email content type.
     self.keyboardType = UIKeyboardTypeEmailAddress;
@@ -160,9 +164,10 @@
     // Set natural text alignment.
     self.textAlignment = NSTextAlignmentNatural;
 
-    // Set minimum font size and font.
+    // Set minimum font size and font — scale with Dynamic Type.
     self.minimumFontSize = 17;
-    self.font = [UIFont systemFontOfSize:14];
+    self.font = [[UIFontMetrics defaultMetrics] scaledFontForFont:[UIFont systemFontOfSize:14]];
+    self.adjustsFontForContentSizeCategory = YES;
 
     // Configure text input traits.
     self.keyboardType = UIKeyboardTypePhonePad;
@@ -211,9 +216,10 @@
     // Set natural text alignment.
     self.textAlignment = NSTextAlignmentNatural;
 
-    // Set minimum font size and font.
+    // Set minimum font size and font — scale with Dynamic Type.
     self.minimumFontSize = 17;
-    self.font = [UIFont systemFontOfSize:14];
+    self.font = [[UIFontMetrics defaultMetrics] scaledFontForFont:[UIFont systemFontOfSize:14]];
+    self.adjustsFontForContentSizeCategory = YES;
 
     // Configure text input traits.
     self.keyboardType = UIKeyboardTypeURL;


### PR DESCRIPTION
## Description

Adopts iOS Dynamic Type for `ACRTextField` (and its `ACRTextEmailField`,
`ACRTextTelelphoneField`, `ACRTextUrlField` subclasses) so input fonts scale
with the user's preferred Larger Text size.

Today the input fonts are pinned with `[UIFont systemFontOfSize:N]` (15pt for
the base text input, 14pt for email/tel/url variants). When a user enables
Larger Text in iOS Accessibility settings, the surrounding card text scales but
the input fields stay at the hardcoded size, breaking visual consistency and
violating WCAG 1.4.4 Resize Text.

## Changes

`source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextField.mm`:

For each of the four `commonInitialization` overrides:
- Wrap the system font with `[UIFontMetrics defaultMetrics] scaledFontForFont:`
- Set `self.adjustsFontForContentSizeCategory = YES`

The `minimumFontSize` floor (used by `UITextField` `adjustsFontSizeToFitWidth`)
is unchanged, so visual layout never collapses below the previous baseline.

## Behavior

- Default Dynamic Type ("Large"): identical visual rendering.
- Larger Dynamic Type sizes: input font scales proportionally, matching
  surrounding `Input.Text.label` and host body text.
- AX1–AX5 accessibility sizes: same scaling, capped by `UIFontMetrics`.
- No object-model, host-config, or public API changes.

## Validation

- Builds clean for iOS (CI: `teams-adaptivecards-ios-pr`).
- Manual: with Larger Text set to AX2, text inputs visually scale alongside
  card body text (previously stayed at 14/15pt).

## Severity

Sev3 — site walkthrough audit (Dynamic Type / Resize Text).
