### PR TITLE
fix(android): add visible keyboard focus indicator to Action buttons

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -7,6 +7,7 @@ import static io.adaptivecards.renderer.inputhandler.InputUtils.isAnyInputValid;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.PorterDuff;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.ContextThemeWrapper;
@@ -15,6 +16,7 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 
 import androidx.appcompat.widget.TooltipCompat;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentManager;
 
 import io.adaptivecards.R;
@@ -116,6 +118,19 @@ public class ActionElementRenderer extends BaseActionElementRenderer
         }
 
         Button button = getButtonForStyle(context, baseActionElement.GetStyle(), hostConfig);
+
+        // Apply a foreground ripple/focus drawable so keyboard users see a clear focus
+        // indicator on the action button (WCAG 2.4.7 Focus Visible). Themed Positive /
+        // Destructive buttons use a ContextThemeWrapper, but the underlying button
+        // background may not include a focus state on every device theme.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            TypedValue focusFg = new TypedValue();
+            if (button.getContext().getTheme().resolveAttribute(android.R.attr.selectableItemBackground, focusFg, true)
+                && focusFg.resourceId != 0
+                && button.getForeground() == null) {
+                button.setForeground(ContextCompat.getDrawable(button.getContext(), focusFg.resourceId));
+            }
+        }
 
         if (Util.isOfType(baseActionElement, ExecuteAction.class) || Util.isOfType(baseActionElement, SubmitAction.class))
         {


### PR DESCRIPTION
## Problem

Action buttons rendered by the SDK have no visible focus indicator when reached by D-pad / keyboard / Switch Control. After PR #643 restores keyboard focusability for container children, focus can land on Action buttons but the user has no visual confirmation of focus location, violating WCAG 2.4.7 (Focus Visible).

## Root Cause

`ActionElementRenderer.renderButton(...)` constructs a plain `android.widget.Button` (or themed variant for Positive / Destructive). The default selectable foreground that ships with the platform `?attr/selectableItemBackground` is *not* automatically applied to programmatically-created `Button` instances on every host app theme — particularly when the host app uses a non-Material parent theme or when the SDK is hosted inside a `ContextThemeWrapper` chain.

The result: focused state has no ripple / outline overlay.

## Fix

In `source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java`:

After `getButtonForStyle(...)`, resolve `android.R.attr.selectableItemBackground` from the *button's own* theme (so themed Positive/Destructive buttons get the right ripple) and assign it as the button's foreground when no foreground is already set.

- Guarded by `SDK_INT >= M` (foreground on `View` requires API 23+; SDK min is already 23+).
- Guarded by `getForeground() == null` so existing custom themes that already set a foreground are not overridden.
- Resolution uses the resolved button's context, not the renderer's input context, so themed buttons (Positive / Destructive) pick up their theme's ripple correctly.

## How Verified

- Builds clean for Android (CI: `teams-adaptivecards-android-pr`).
- Manual: with TalkBack off and external keyboard attached, Tab through a card with multiple Actions — each Action now shows the platform ripple/outline on focus.
- No visual change for pointer / touch interactions.
- No public API change.

Fixes: AB#5342984
