### PR TITLE
fix(android): allow Action button text to wrap with system font scale

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -125,6 +125,13 @@ public class ActionElementRenderer extends BaseActionElementRenderer
         setButtonEnabledState(baseActionElement, button, renderedCard);
 
         button.setText(baseActionElement.GetTitle());
+        // Allow Action button text to wrap (up to 2 lines) instead of being clipped
+        // when the user increases system font scale (Settings > Display > Font size).
+        // The default android.widget.Button is effectively single-line on most themes
+        // and either truncates or clips characters when scaled text exceeds the
+        // available width. Wrapping respects WCAG 1.4.4 (Resize Text).
+        button.setMaxLines(2);
+        button.setEllipsize(null);
         if (!TextUtils.isEmpty(baseActionElement.GetTooltip()))
         {
             TooltipCompat.setTooltipText(button, baseActionElement.GetTooltip());


### PR DESCRIPTION
## Problem

When the user increases Android system font scale (Settings > Display > Font size > Largest), Action button text on adaptive cards is clipped or vertically cropped — e.g. the "Start Walkthrough" button on the Site Walkthrough cards loses the last characters.

## Root Cause

`ActionElementRenderer.renderButton(...)` constructs a vanilla `android.widget.Button` and assigns its title via `button.setText(...)`. The default `android.widget.Button` styling is effectively single-line on the device themes the SDK is shipped against — once scaled text exceeds the available width, characters are silently truncated rather than wrapped, and there is no `setMaxLines` / `setEllipsize` override.

## Fix

In `source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java`, immediately after `button.setText(baseActionElement.GetTitle())`:

```java
button.setMaxLines(2);
button.setEllipsize(null);
```

This lets long / scaled action titles wrap to a second line. The existing `MATCH_PARENT` height on the button's `LinearLayout.LayoutParams` (and `MATCH_PARENT` on its parent) means the surrounding actions row grows to accommodate the tallest wrapped button — visual layout stays consistent.

## Why two lines (not unlimited)

- One line is the existing visible budget. Allowing two lines covers all of Android's font scale presets including AX5 (`fontScale ≈ 1.30`) for typical English action titles up to ~25 characters.
- Capping at 2 prevents pathologically long titles from collapsing the rest of the card.
- Hosts that need a different cap can subclass and override.

## How Verified

- Builds clean for Android (CI: `teams-adaptivecards-android-pr`).
- Manual: with `fontScale = 1.30`, the "Start Walkthrough" button now wraps to two lines instead of clipping.
- No visual regression at default font scale.
- No public API change.

Fixes: AB#5342648
