### PR TITLE
fix(android): scale Badge icon with system font scale

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/BadgeView.kt
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/BadgeView.kt
@@ -104,6 +104,15 @@ class BadgeView(
         iconView.loadIcon(badge.GetBadgeIcon(), badge.GetBadgeSize(), badgeConfig, renderedCard)
     }
 
+    /**
+     * System font scale (clamped at >= 1.0) used to scale the badge icon so it
+     * grows in lockstep with the SP-scaled text. Without this, increasing
+     * Android's font size in Settings makes the badge text grow while the icon
+     * stays at its hardcoded dp size, producing a visually mismatched badge.
+     */
+    private val fontScale: Float
+        get() = context.resources.configuration.fontScale.coerceAtLeast(1f)
+
     private fun ImageView.loadIcon(
         icon: String,
         badgeSize: BadgeSize,
@@ -121,7 +130,9 @@ class BadgeView(
 
         val foregroundColor: String = badgeConfig.textColor
 
-        val iconSize = badgeSize.getIconSize()
+        // Scale the icon size by the system font scale so the icon grows
+        // proportionally with the SP-scaled badge text (WCAG 1.4.4 Resize Text).
+        val iconSize = (badgeSize.getIconSize() * fontScale).toLong()
 
         val fluentIconImageLoaderAsync = FluentIconImageLoaderAsync(
             renderedCard,


### PR DESCRIPTION
## Problem

When the user increases the Android system font scale (Settings > Display > Font size), the text of `Badge` elements scales correctly (text uses SP units), but the badge **icon** stays at its hardcoded dp size (12dp / 16dp). The result is a visually mismatched badge — disproportionately large text next to a tiny icon — and on circular badges the now-tall text can extend beyond the icon's vertical bounds.

This is part of the Site Walkthrough A11y audit (badge-style "AI Generated" label clipping at large font scales).

## Root Cause

`BadgeView.addIconView(...)` → `loadIcon(...)` resolves the target icon size via `BadgeSize.getIconSize()` which returns a constant `12L` or `16L`. That value is passed verbatim to `FluentIconImageLoaderAsync(targetIconSize = …)` and used to size the SVG drawable. Nothing in the path consults `Configuration.fontScale`.

## Fix

In `source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/BadgeView.kt`:

1. Add a `fontScale` getter that reads `context.resources.configuration.fontScale`, clamped at `>= 1f` so we never *shrink* the icon below the design baseline.
2. In `loadIcon(...)`, multiply `badgeSize.getIconSize()` by `fontScale` before constructing the loader.

This keeps the icon visually proportional to the SP-scaled text across all of Android's font scale presets (Default → AX5 ≈ 1.30x).

## Why not also scale corner radius / padding

- Corner radius is rendered as a `GradientDrawable` background — for circular badges, a radius >= half-height fully rounds the corners regardless of size, so it auto-adapts.
- Padding (`badge_padding_top_bottom = 4dp`) is intentionally fixed visual breathing room.
- These can be revisited if user reports require it.

## How Verified

- Builds clean for Android (CI: `teams-adaptivecards-android-pr`).
- Manual: with `fontScale = 1.30`, badge icon now scales to ~16dp / ~21dp, matching the larger text. At default fontScale, output is byte-identical.
- No public API change.
- No model / object-model change.

## Scope Note

The originating bug also describes "fixed `layout_height` clipping" on a TextBlock-rendered badge in a host card. That part is card-author / host-side and not addressable in the SDK itself; this PR fixes the SDK-side text-resize parity for the new `Badge` element so future cards using `Badge` (the recommended replacement) scale correctly out of the box.

Fixes: AB#5342651
