### PR TITLE
Add NPE check and warning for null images

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/GenericImageLoaderAsync.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/GenericImageLoaderAsync.java
@@ -242,8 +242,12 @@ public abstract class GenericImageLoaderAsync extends AsyncTask<String, Void, Ht
             if(image != null) {
                 image = styleBitmap(image);
                 image.setDensity(DisplayMetrics.DENSITY_DEFAULT);
+                onSuccessfulPostExecute(image);
             }
-            onSuccessfulPostExecute(image);
+            else if (m_renderedCard != null)
+            {
+                m_renderedCard.addWarning(new AdaptiveWarning(AdaptiveWarning.UNABLE_TO_LOAD_IMAGE, "Image could not be decoded"));
+            }
         }
         else
         {


### PR DESCRIPTION
# Description

NPE crash: 
04-17 11:02:24.353  3307  3307 E AndroidRuntime: FATAL EXCEPTION: main
04-17 11:02:24.353  3307  3307 E AndroidRuntime: Process: com.microsoft.teams, PID: 3307
04-17 11:02:24.353  3307  3307 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.graphics.Bitmap.getWidth()' on a null object reference
04-17 11:02:24.353  3307  3307 E AndroidRuntime: at io.adaptivecards.renderer.BackgroundImageLoaderAsync.onSuccessfulPostExecute(Unknown Source:18)
04-17 11:02:24.353  3307  3307 E AndroidRuntime: at io.adaptivecards.renderer.GenericImageLoaderAsync.onPostExecute(SourceFile:6)
04-17 11:02:24.353  3307  3307 E AndroidRuntime: at io.adaptivecards.renderer.GenericImageLoaderAsync.onPostExecute(SourceFile:1)