### PR TITLE
[iOS] Fix missing bullet markers in TextBlock markdown lists.

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -750,6 +750,19 @@ void buildIntermediateResultForText(ACRView *rootView, ACOHostConfig *hostConfig
     }
     NSString *parsedString = (markDownParser->HasHtmlTags()) ? [NSString stringWithCString:markdownString.c_str() encoding:NSUTF8StringEncoding] : [NSString stringWithCString:markDownParser->GetRawText().c_str() encoding:NSUTF8StringEncoding];
 
+    // Convert <ul>/<li> to literal "• " bullets and <br> separators.
+    // Apple's NSHTMLTextDocumentType renders list bullets via NSTextList in the
+    // paragraph style, which is overwritten downstream in ACRTextBlockRenderer
+    // when alignment is applied — wiping out the bullet markers. Mirroring the
+    // Android renderer (RendererUtil.UlTagHandler) by injecting bullets as text
+    // makes the marker survive any paragraph-style changes.
+    if (markDownParser->HasHtmlTags() && [parsedString containsString:@"<li>"]) {
+        parsedString = [parsedString stringByReplacingOccurrencesOfString:@"<ul>" withString:@""];
+        parsedString = [parsedString stringByReplacingOccurrencesOfString:@"</ul>" withString:@""];
+        parsedString = [parsedString stringByReplacingOccurrencesOfString:@"<li>" withString:@"• "];
+        parsedString = [parsedString stringByReplacingOccurrencesOfString:@"</li>" withString:@"<br>"];
+    }
+
     if (markDownParser->HasHtmlTags() && ([parsedString containsString:@"\n"] || [parsedString containsString:@"\r"])) {
         // Different systems have different line break styles
         // Windows style: \r\n

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -756,11 +756,78 @@ void buildIntermediateResultForText(ACRView *rootView, ACOHostConfig *hostConfig
     // when alignment is applied — wiping out the bullet markers. Mirroring the
     // Android renderer (RendererUtil.UlTagHandler) by injecting bullets as text
     // makes the marker survive any paragraph-style changes.
-    if (markDownParser->HasHtmlTags() && [parsedString containsString:@"<li>"]) {
-        parsedString = [parsedString stringByReplacingOccurrencesOfString:@"<ul>" withString:@""];
-        parsedString = [parsedString stringByReplacingOccurrencesOfString:@"</ul>" withString:@""];
-        parsedString = [parsedString stringByReplacingOccurrencesOfString:@"<li>" withString:@"• "];
-        parsedString = [parsedString stringByReplacingOccurrencesOfString:@"</li>" withString:@"<br>"];
+    //
+    // Single-pass scan with a stack per tag kind: each opener records its
+    // position in the output buffer; the matching closer rewrites that
+    // position (<li> → "• ", <ul> → removed) and emits its own replacement.
+    // An unmatched opener stays as-is in the output; an unmatched closer is
+    // emitted verbatim — neither is silently dropped.
+    if (markDownParser->HasHtmlTags() && [parsedString containsString:@"<ul>"]) {
+        NSUInteger length = parsedString.length;
+        NSMutableString *output = [NSMutableString stringWithCapacity:length];
+        NSMutableArray<NSNumber *> *ulOpenerPositions = [NSMutableArray array];
+        NSMutableArray<NSNumber *> *liOpenerPositions = [NSMutableArray array];
+        NSUInteger chunkStart = 0;
+        NSUInteger i = 0;
+
+        while (i < length) {
+            if ([parsedString characterAtIndex:i] != '<') {
+                i++;
+                continue;
+            }
+
+            NSString *tag4 = (i + 4 <= length) ? [parsedString substringWithRange:NSMakeRange(i, 4)] : nil;
+            NSString *tag5 = (i + 5 <= length) ? [parsedString substringWithRange:NSMakeRange(i, 5)] : nil;
+
+            BOOL isUlOpen = [tag4 isEqualToString:@"<ul>"];
+            BOOL isLiOpen = [tag4 isEqualToString:@"<li>"];
+            BOOL isUlClose = [tag5 isEqualToString:@"</ul>"];
+            BOOL isLiClose = [tag5 isEqualToString:@"</li>"];
+
+            if (!(isUlOpen || isLiOpen || isUlClose || isLiClose)) {
+                i++;
+                continue;
+            }
+
+            // Flush text between the last tag and this one.
+            if (i > chunkStart) {
+                [output appendString:[parsedString substringWithRange:NSMakeRange(chunkStart, i - chunkStart)]];
+            }
+
+            if (isUlOpen) {
+                [ulOpenerPositions addObject:@(output.length)];
+                [output appendString:@"<ul>"];
+                i += 4;
+            } else if (isLiOpen) {
+                [liOpenerPositions addObject:@(output.length)];
+                [output appendString:@"<li>"];
+                i += 4;
+            } else if (isUlClose) {
+                if (ulOpenerPositions.count > 0) {
+                    NSUInteger openerPos = ulOpenerPositions.lastObject.unsignedIntegerValue;
+                    [ulOpenerPositions removeLastObject];
+                    [output deleteCharactersInRange:NSMakeRange(openerPos, 4)];
+                } else {
+                    [output appendString:@"</ul>"];
+                }
+                i += 5;
+            } else {
+                if (liOpenerPositions.count > 0) {
+                    NSUInteger openerPos = liOpenerPositions.lastObject.unsignedIntegerValue;
+                    [liOpenerPositions removeLastObject];
+                    [output replaceCharactersInRange:NSMakeRange(openerPos, 4) withString:@"• "];
+                    [output appendString:@"<br>"];
+                } else {
+                    [output appendString:@"</li>"];
+                }
+                i += 5;
+            }
+            chunkStart = i;
+        }
+        if (chunkStart < length) {
+            [output appendString:[parsedString substringFromIndex:chunkStart]];
+        }
+        parsedString = output;
     }
 
     if (markDownParser->HasHtmlTags() && ([parsedString containsString:@"\n"] || [parsedString containsString:@"\r"])) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -756,78 +756,27 @@ void buildIntermediateResultForText(ACRView *rootView, ACOHostConfig *hostConfig
     // when alignment is applied — wiping out the bullet markers. Mirroring the
     // Android renderer (RendererUtil.UlTagHandler) by injecting bullets as text
     // makes the marker survive any paragraph-style changes.
-    //
-    // Single-pass scan with a stack per tag kind: each opener records its
-    // position in the output buffer; the matching closer rewrites that
-    // position (<li> → "• ", <ul> → removed) and emits its own replacement.
-    // An unmatched opener stays as-is in the output; an unmatched closer is
-    // emitted verbatim — neither is silently dropped.
-    if (markDownParser->HasHtmlTags() && [parsedString containsString:@"<ul>"]) {
-        NSUInteger length = parsedString.length;
-        NSMutableString *output = [NSMutableString stringWithCapacity:length];
-        NSMutableArray<NSNumber *> *ulOpenerPositions = [NSMutableArray array];
-        NSMutableArray<NSNumber *> *liOpenerPositions = [NSMutableArray array];
-        NSUInteger chunkStart = 0;
-        NSUInteger i = 0;
+    if (markDownParser->HasHtmlTags() && [parsedString containsString:@"<li>"]) {
+        // Strip the list containers, then rewrite each well-formed <li>…</li>
+        // pair into a "• " line ending in <br>. Matching the pair with one
+        // regex avoids leaking a half-formed bullet from a stray <li> or </li>.
+        NSRegularExpression *ulRegex =
+            [NSRegularExpression regularExpressionWithPattern:@"<ul>(.*?)</ul>"
+                                                      options:NSRegularExpressionDotMatchesLineSeparators
+                                                        error:nil];
+        parsedString = [ulRegex stringByReplacingMatchesInString:parsedString
+                                                         options:0
+                                                           range:NSMakeRange(0, parsedString.length)
+                                                    withTemplate:@"$1"];
 
-        while (i < length) {
-            if ([parsedString characterAtIndex:i] != '<') {
-                i++;
-                continue;
-            }
-
-            NSString *tag4 = (i + 4 <= length) ? [parsedString substringWithRange:NSMakeRange(i, 4)] : nil;
-            NSString *tag5 = (i + 5 <= length) ? [parsedString substringWithRange:NSMakeRange(i, 5)] : nil;
-
-            BOOL isUlOpen = [tag4 isEqualToString:@"<ul>"];
-            BOOL isLiOpen = [tag4 isEqualToString:@"<li>"];
-            BOOL isUlClose = [tag5 isEqualToString:@"</ul>"];
-            BOOL isLiClose = [tag5 isEqualToString:@"</li>"];
-
-            if (!(isUlOpen || isLiOpen || isUlClose || isLiClose)) {
-                i++;
-                continue;
-            }
-
-            // Flush text between the last tag and this one.
-            if (i > chunkStart) {
-                [output appendString:[parsedString substringWithRange:NSMakeRange(chunkStart, i - chunkStart)]];
-            }
-
-            if (isUlOpen) {
-                [ulOpenerPositions addObject:@(output.length)];
-                [output appendString:@"<ul>"];
-                i += 4;
-            } else if (isLiOpen) {
-                [liOpenerPositions addObject:@(output.length)];
-                [output appendString:@"<li>"];
-                i += 4;
-            } else if (isUlClose) {
-                if (ulOpenerPositions.count > 0) {
-                    NSUInteger openerPos = ulOpenerPositions.lastObject.unsignedIntegerValue;
-                    [ulOpenerPositions removeLastObject];
-                    [output deleteCharactersInRange:NSMakeRange(openerPos, 4)];
-                } else {
-                    [output appendString:@"</ul>"];
-                }
-                i += 5;
-            } else {
-                if (liOpenerPositions.count > 0) {
-                    NSUInteger openerPos = liOpenerPositions.lastObject.unsignedIntegerValue;
-                    [liOpenerPositions removeLastObject];
-                    [output replaceCharactersInRange:NSMakeRange(openerPos, 4) withString:@"• "];
-                    [output appendString:@"<br>"];
-                } else {
-                    [output appendString:@"</li>"];
-                }
-                i += 5;
-            }
-            chunkStart = i;
-        }
-        if (chunkStart < length) {
-            [output appendString:[parsedString substringFromIndex:chunkStart]];
-        }
-        parsedString = output;
+        NSRegularExpression *liRegex =
+            [NSRegularExpression regularExpressionWithPattern:@"<li>(.*?)</li>"
+                                                      options:NSRegularExpressionDotMatchesLineSeparators
+                                                        error:nil];
+        parsedString = [liRegex stringByReplacingMatchesInString:parsedString
+                                                         options:0
+                                                           range:NSMakeRange(0, parsedString.length)
+                                                    withTemplate:@"• $1<br>"];
     }
 
     if (markDownParser->HasHtmlTags() && ([parsedString containsString:@"\n"] || [parsedString containsString:@"\r"])) {


### PR DESCRIPTION
# Explain defect

TextBlocks containing markdown unordered lists (e.g. `"- Item 1"`) render on iOS without the leading bullet marker — the text appears but the `•` is missing. The shared C++ markdown parser correctly emits `<ul><li>Item 1</li></ul>`, but on modern iOS `NSHTMLTextDocumentType` renders the bullet via `NSTextList` inside the paragraph style rather than as a literal character in the text. `ACRTextBlockRenderer` then overwrites every paragraph style with a fresh `NSMutableParagraphStyle` (only `alignment` is set) to honor the host-config alignment, which wipes out `NSTextList`, head-indent, and tab-stops — leaving the text without its bullet marker.

# Explain fix

In `buildIntermediateResultForText` (`UtiliOS.mm`), preprocess the markdown→HTML output before feeding it to `NSAttributedString`: strip` <ul>/</ul>`, replace `<li> `with `"• ",` and replace `</li>` with `<br>`. The bullet now lives in the text itself, so it survives any downstream paragraph-style changes and renders consistently across iOS versions. This mirrors the Android renderer's `RendererUtil.UlTagHandler`, which already injects literal `"\n• "` bullets into the spannable. Because the fix is in the shared `buildIntermediateResultForText`, it applies uniformly to `TextBlock`, `RichTextBlock`, and `FactSet`.


