### PR TITLE
Action run commands Fixes

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOEnums.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOEnums.h
@@ -16,6 +16,7 @@ typedef NS_ENUM(NSInteger, ACRActionType) {
     ACRToggleVisibility,
     ACROverflow,
     ACRUnknownAction = 8,
+    ACRRunCommands,
 };
 
 typedef NS_ENUM(NSInteger, ACRIconPlacement) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOEnums.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOEnums.h
@@ -16,7 +16,6 @@ typedef NS_ENUM(NSInteger, ACRActionType) {
     ACRToggleVisibility,
     ACROverflow,
     ACRUnknownAction = 8,
-    ACRRunCommands,
 };
 
 typedef NS_ENUM(NSInteger, ACRIconPlacement) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -441,12 +441,13 @@ NSString * const DYNAMIC_VISIBLE_PROP = @"isVisible.dynamic";
 + (void)evaluateDynamicProperties:(NSString * _Nullable)titleDynamic
                  isVisibleDynamic:(NSString * _Nullable)isVisibleDynamic
                  isEnabledDynamic:(NSString * _Nullable)isEnabledDynamic
+                      dataContext:(NSDictionary * _Nullable)dataContext
                            button:(ACRButton *)button
     {
-        
+
         if (titleDynamic && [titleDynamic isKindOfClass:[NSString class]] && titleDynamic.length > 0)
         {
-            [self evaluateExpression:titleDynamic completion:^(id value, NSError *error)
+            [self evaluateExpression:titleDynamic withData:dataContext completion:^(id value, NSError *error)
              {
                 if ([value isKindOfClass:[NSString class]] && [((NSString *)value) length] > 0)
                 {
@@ -458,7 +459,7 @@ NSString * const DYNAMIC_VISIBLE_PROP = @"isVisible.dynamic";
         }
         if (isVisibleDynamic && [isVisibleDynamic isKindOfClass:[NSString class]] && isVisibleDynamic.length > 0)
         {
-            [self evaluateExpression:isVisibleDynamic completion:^(id value, NSError *error)
+            [self evaluateExpression:isVisibleDynamic withData:dataContext completion:^(id value, NSError *error)
              {
                 if ([value isKindOfClass:[NSNumber class]])
                 {
@@ -469,10 +470,10 @@ NSString * const DYNAMIC_VISIBLE_PROP = @"isVisible.dynamic";
                 }
             }];
         }
-        
+
         if (isEnabledDynamic && [isEnabledDynamic isKindOfClass:[NSString class]] && isEnabledDynamic.length > 0)
         {
-            [self evaluateExpression:isEnabledDynamic completion:^(id value, NSError *error)
+            [self evaluateExpression:isEnabledDynamic withData:dataContext completion:^(id value, NSError *error)
              {
                 if ([value isKindOfClass:[NSNumber class]])
                 {
@@ -488,7 +489,6 @@ NSString * const DYNAMIC_VISIBLE_PROP = @"isVisible.dynamic";
 + (void)handleExpressionEvaluationForButton:(ACRButton *)button
                           baseActionElement:(ACOBaseActionElement *)acoElem
 {
-   
     NSData *additionalProperty = [acoElem additionalProperty];
     if (additionalProperty)
     {
@@ -498,18 +498,17 @@ NSString * const DYNAMIC_VISIBLE_PROP = @"isVisible.dynamic";
         NSString * _Nullable titleDynamic = additionalProperties[DYNAMIC_TITLE_PROP];
         NSString * _Nullable isEnabledDynamic = additionalProperties[DYNAMIC_ENABLE_PROP];
         NSString * _Nullable isVisibleDynamic = additionalProperties[DYNAMIC_VISIBLE_PROP];
+        NSDictionary * _Nullable dataContext = additionalProperties[@"data"];
         [self evaluateDynamicProperties:titleDynamic
                        isVisibleDynamic:isVisibleDynamic
                        isEnabledDynamic:isEnabledDynamic
+                            dataContext:dataContext
                                  button:button];
     }
-
 }
 
-/// Evaluates an expression string using the Swift ObjCExpressionEvaluator bridge.
-/// Calls the completion block with success/failure and result/error.
-+ (void)evaluateExpression:(NSString *)expression completion:(void (^)(id _Nullable result, NSError * _Nullable error))completion {
-    [TSExpressionObjCBridge evaluateExpression:expression withData:nil completion:^(NSObject * _Nullable evalResult, NSError * _Nullable evalError)
++ (void)evaluateExpression:(NSString *)expression withData:(NSDictionary * _Nullable)data completion:(void (^)(id _Nullable result, NSError * _Nullable error))completion {
+    [TSExpressionObjCBridge evaluateExpression:expression withData:data completion:^(NSObject * _Nullable evalResult, NSError * _Nullable evalError)
      {
         if (completion)
         {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
@@ -220,20 +220,23 @@ NSString * const DYNAMIC_TEXT_PROP = @"text.dynamic";
         additionalProperties = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&jsonError];
         if (additionalProperties && [additionalProperties isKindOfClass:[NSDictionary class]])
         {
-            NSString *titleDynamic = additionalProperties[DYNAMIC_TEXT_PROP];
-            
-            [self evaluateDynamicProperties:titleDynamic
+            NSString *textDynamic = additionalProperties[DYNAMIC_TEXT_PROP];
+            NSDictionary * _Nullable dataContext = additionalProperties[@"data"];
+
+            [self evaluateDynamicProperties:textDynamic
+                                dataContext:dataContext
                                       label:label];
         }
     }
 }
 
 - (void)evaluateDynamicProperties:(NSString * _Nullable)textDynamic
+                      dataContext:(NSDictionary * _Nullable)dataContext
                             label:(ACRViewAttachingTextView *)label
 {
     if (textDynamic && [textDynamic length] > 0)
     {
-        [self evaluateExpression:textDynamic completion:^(id value, NSError *error)
+        [self evaluateExpression:textDynamic withData:dataContext completion:^(id value, NSError *error)
          {
             if ([value isKindOfClass:[NSString class]] && [((NSString *)value) length] > 0)
             {
@@ -245,11 +248,9 @@ NSString * const DYNAMIC_TEXT_PROP = @"text.dynamic";
     }
 }
 
-/// Evaluates an expression string using the Swift ObjCExpressionEvaluator bridge.
-/// Calls the completion block with success/failure and result/error.
-- (void)evaluateExpression:(NSString *)expression completion:(void (^)(id _Nullable result, NSError * _Nullable error))completion
+- (void)evaluateExpression:(NSString *)expression withData:(NSDictionary * _Nullable)data completion:(void (^)(id _Nullable result, NSError * _Nullable error))completion
 {
-    [TSExpressionObjCBridge evaluateExpression:expression withData:nil completion:^(NSObject * _Nullable evalResult, NSError * _Nullable evalError)
+    [TSExpressionObjCBridge evaluateExpression:expression withData:data completion:^(NSObject * _Nullable evalResult, NSError * _Nullable evalError)
      {
         if (completion)
         {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionHelpers.swift
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionHelpers.swift
@@ -17,7 +17,6 @@ import Foundation
     private let engine: ExpressionEngineProtocol
     private var expressionEvalEnabled = false
     private var hostFunctions: [FunctionDeclaration] = []
-    private let hostFunctionsQueue = DispatchQueue(label: "com.adaptivecards.hostFunctions")
 
     // Private initializer prevents external instantiation
     private override init() {
@@ -40,27 +39,21 @@ import Foundation
     /// Register a host-provided function that expressions can call.
     /// Registered functions are available to all subsequent expression evaluations.
     public static func registerHostFunction(_ declaration: FunctionDeclaration) {
-        shared.hostFunctionsQueue.sync {
+        shared.hostFunctions.removeAll { $0.name == declaration.name }
+        shared.hostFunctions.append(declaration)
+    }
+
+    /// Register multiple host-provided functions.
+    public static func registerHostFunctions(_ declarations: [FunctionDeclaration]) {
+        for declaration in declarations {
             shared.hostFunctions.removeAll { $0.name == declaration.name }
             shared.hostFunctions.append(declaration)
         }
     }
 
-    /// Register multiple host-provided functions.
-    public static func registerHostFunctions(_ declarations: [FunctionDeclaration]) {
-        shared.hostFunctionsQueue.sync {
-            for declaration in declarations {
-                shared.hostFunctions.removeAll { $0.name == declaration.name }
-                shared.hostFunctions.append(declaration)
-            }
-        }
-    }
-
     /// Remove all registered host functions.
     @objc public static func removeAllHostFunctions() {
-        shared.hostFunctionsQueue.sync {
-            shared.hostFunctions.removeAll()
-        }
+        shared.hostFunctions.removeAll()
     }
 
     // Static convenience method for backward compatibility
@@ -75,7 +68,7 @@ import Foundation
             do {
                 let expr = try engine.createExpression(expressionString, allowAssignment: false)
 
-                let functions = self.hostFunctionsQueue.sync { self.hostFunctions }
+                let functions = self.hostFunctions
 
                 let config = EvaluationContextConfig(
                     root: data as? [String: Any],

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionHelpers.swift
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionHelpers.swift
@@ -17,6 +17,7 @@ import Foundation
     private let engine: ExpressionEngineProtocol
     private var expressionEvalEnabled = false
     private var hostFunctions: [FunctionDeclaration] = []
+    private let lock = NSLock()
 
     // Private initializer prevents external instantiation
     private override init() {
@@ -39,19 +40,26 @@ import Foundation
     /// Register a host-provided function that expressions can call.
     /// Registered functions are available to all subsequent expression evaluations.
     public static func registerHostFunction(_ declaration: FunctionDeclaration) {
+        shared.lock.lock()
+        defer { shared.lock.unlock() }
         shared.hostFunctions.removeAll { $0.name == declaration.name }
         shared.hostFunctions.append(declaration)
     }
 
     /// Register multiple host-provided functions.
     public static func registerHostFunctions(_ declarations: [FunctionDeclaration]) {
+        shared.lock.lock()
+        defer { shared.lock.unlock() }
         for declaration in declarations {
-            registerHostFunction(declaration)
+            shared.hostFunctions.removeAll { $0.name == declaration.name }
+            shared.hostFunctions.append(declaration)
         }
     }
 
     /// Remove all registered host functions.
     @objc public static func removeAllHostFunctions() {
+        shared.lock.lock()
+        defer { shared.lock.unlock() }
         shared.hostFunctions.removeAll()
     }
 
@@ -67,9 +75,13 @@ import Foundation
             do {
                 let expr = try engine.createExpression(expressionString, allowAssignment: false)
 
+                self.lock.lock()
+                let functions = self.hostFunctions
+                self.lock.unlock()
+
                 let config = EvaluationContextConfig(
                     root: data as? [String: Any],
-                    functions: hostFunctions
+                    functions: functions
                 )
                 let context = await EvaluationContext(config: config)
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionHelpers.swift
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionHelpers.swift
@@ -11,49 +11,70 @@ import Foundation
 // MARK: - Objective-C Bridge Implementation
 
 @objc public class ObjCExpressionEvaluator: NSObject {
-    
+
     @objc public static let shared = ObjCExpressionEvaluator()
-    
+
     private let engine: ExpressionEngineProtocol
     private var expressionEvalEnabled = false
-    
+    private var hostFunctions: [FunctionDeclaration] = []
+
     // Private initializer prevents external instantiation
     private override init() {
         self.engine = ExpressionEngine()
         super.init()
     }
-    
+
     // MARK: - Configuration
-    
+
     @objc public static func setExpressionEvalEnabled(_ isEnabled: Bool) {
         shared.expressionEvalEnabled = isEnabled
     }
-    
+
     @objc public static func isExpressionEvalEnabled() -> Bool {
         return shared.expressionEvalEnabled
     }
-        
+
+    // MARK: - Host Function Registration
+
+    /// Register a host-provided function that expressions can call.
+    /// Registered functions are available to all subsequent expression evaluations.
+    public static func registerHostFunction(_ declaration: FunctionDeclaration) {
+        shared.hostFunctions.removeAll { $0.name == declaration.name }
+        shared.hostFunctions.append(declaration)
+    }
+
+    /// Register multiple host-provided functions.
+    public static func registerHostFunctions(_ declarations: [FunctionDeclaration]) {
+        for declaration in declarations {
+            registerHostFunction(declaration)
+        }
+    }
+
+    /// Remove all registered host functions.
+    @objc public static func removeAllHostFunctions() {
+        shared.hostFunctions.removeAll()
+    }
+
     // Static convenience method for backward compatibility
     @objc public static func evaluateExpression(_ expressionString: String, withData data: NSDictionary? = nil, completion: @escaping (NSObject?, NSError?) -> Void) {
         shared.evaluateExpression(expressionString, withData: data, completion: completion)
     }
-    
+
     /// Instance method for evaluating expressions
     @objc public func evaluateExpression(_ expressionString: String, withData data: NSDictionary? = nil, completion: @escaping (NSObject?, NSError?) -> Void) {
-        
+
         Task {
             do {
                 let expr = try engine.createExpression(expressionString, allowAssignment: false)
-                let context: EvaluationContext?
-                
-                if let data = data {
-                    context = await engine.createContext(with: data as? [String: Any])
-                } else {
-                    context = await engine.createDefaultContext(with: nil)
-                }
-                
+
+                let config = EvaluationContextConfig(
+                    root: data as? [String: Any],
+                    functions: hostFunctions
+                )
+                let context = await EvaluationContext(config: config)
+
                 let result = await expr.evaluateResult(context: context)
-                
+
                 switch result {
                 case .success(let value):
                     if let nsObj = value as? NSObject {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionHelpers.swift
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionHelpers.swift
@@ -17,7 +17,7 @@ import Foundation
     private let engine: ExpressionEngineProtocol
     private var expressionEvalEnabled = false
     private var hostFunctions: [FunctionDeclaration] = []
-    private let lock = NSLock()
+    private let hostFunctionsQueue = DispatchQueue(label: "com.adaptivecards.hostFunctions")
 
     // Private initializer prevents external instantiation
     private override init() {
@@ -40,27 +40,27 @@ import Foundation
     /// Register a host-provided function that expressions can call.
     /// Registered functions are available to all subsequent expression evaluations.
     public static func registerHostFunction(_ declaration: FunctionDeclaration) {
-        shared.lock.lock()
-        defer { shared.lock.unlock() }
-        shared.hostFunctions.removeAll { $0.name == declaration.name }
-        shared.hostFunctions.append(declaration)
-    }
-
-    /// Register multiple host-provided functions.
-    public static func registerHostFunctions(_ declarations: [FunctionDeclaration]) {
-        shared.lock.lock()
-        defer { shared.lock.unlock() }
-        for declaration in declarations {
+        shared.hostFunctionsQueue.sync {
             shared.hostFunctions.removeAll { $0.name == declaration.name }
             shared.hostFunctions.append(declaration)
         }
     }
 
+    /// Register multiple host-provided functions.
+    public static func registerHostFunctions(_ declarations: [FunctionDeclaration]) {
+        shared.hostFunctionsQueue.sync {
+            for declaration in declarations {
+                shared.hostFunctions.removeAll { $0.name == declaration.name }
+                shared.hostFunctions.append(declaration)
+            }
+        }
+    }
+
     /// Remove all registered host functions.
     @objc public static func removeAllHostFunctions() {
-        shared.lock.lock()
-        defer { shared.lock.unlock() }
-        shared.hostFunctions.removeAll()
+        shared.hostFunctionsQueue.sync {
+            shared.hostFunctions.removeAll()
+        }
     }
 
     // Static convenience method for backward compatibility
@@ -75,9 +75,7 @@ import Foundation
             do {
                 let expr = try engine.createExpression(expressionString, allowAssignment: false)
 
-                self.lock.lock()
-                let functions = self.hostFunctions
-                self.lock.unlock()
+                let functions = self.hostFunctionsQueue.sync { self.hostFunctions }
 
                 let config = EvaluationContextConfig(
                     root: data as? [String: Any],

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionNodes.swift
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionNodes.swift
@@ -87,10 +87,11 @@ public class IdentifierNode: EvaluationNode {
     public func evaluate(context: EvaluationContext) async throws -> EvaluationResult {
         guard let identifier = identifier else { return nil }
 
-        // Handle $var prefix — return the variable scope as a dictionary
+        // Handle $var prefix — return the variable scope as a [String: Any] dictionary
         // so PathNode can resolve $var.result → variableScope["result"]
         if identifier == "$var" {
-            return await context.allVariables
+            let vars = await context.allVariables
+            return vars.compactMapValues { $0 }
         }
 
         // First check variable scope using the actor's public method

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionNodes.swift
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionNodes.swift
@@ -87,6 +87,12 @@ public class IdentifierNode: EvaluationNode {
     public func evaluate(context: EvaluationContext) async throws -> EvaluationResult {
         guard let identifier = identifier else { return nil }
 
+        // Handle $var prefix — return the variable scope as a dictionary
+        // so PathNode can resolve $var.result → variableScope["result"]
+        if identifier == "$var" {
+            return await context.allVariables
+        }
+
         // First check variable scope using the actor's public method
         if let value = await context.getVariable(identifier) {
             return value

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionParser.swift
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/SwiftAdaptiveCards/ExpressionEngine/ExpressionParser.swift
@@ -150,6 +150,11 @@ public class ExpressionParser {
             throw TokenizerError.unexpectedCharacter("Unexpected end of expression.")
         }
         switch curr.type {
+        case "${":
+            moveNext()
+            let inner = try parsePath()
+            _ = try parseToken("}")
+            return inner
         case "identifier", "(":
             return try parsePath()
         case "[":


### PR DESCRIPTION
#                                                         
  Fixes and enhancements to the iOS Expression Engine to support Action.RunCommands and .dynamic property evaluation.                                                 
   
  - **ExpressionNodes.swift**: Handle `$var` prefix in `IdentifierNode.evaluate()` — returns variable scope as dictionary so `$var.result` resolves after `:=`        
  assignment                                             
  - **ExpressionParser.swift**: Handle `${...}` binding syntax in `parsePrimary()` — strips `${` and `}` tokens, parses inner expression. String literals containing  
  `${` are unaffected (tokenizer handles them first)                                                                                                                  
  `EvaluationContext` creation to use a single code path that always includes registered host functions                                                               
  - **ACRButton.mm**: Extract `data` from element's `additionalProperties` and pass as data context to `.dynamic` property evaluation (`isEnabled.dynamic`,
  `isVisible.dynamic`, `title.dynamic`). Previously hardcoded `withData:nil`                                                                                          
  - **ACRTextBlockRenderer.mm**: Same data context fix for `text.dynamic
  
                                                                                                                                                                        
  | Expression | Before | After |                                                                                                                                     
  |-----------|--------|-------|
  | `$var.result` (after `:=` assignment) | `undefinedVariable` | Resolves correctly |                                                                                
  | `approveRequest(${request.id})` | Parser throws on `${` | Resolves to `approveRequest(request.id)` |                                                              
  | `isEnabled.dynamic: "${status == 'pending'}"` with `data` | `withData:nil` — can't resolve | Data passed from `additionalProperties` |                            
  | Host function calls in `.dynamic` | No registration API | `registerHostFunction` available |