### PR TITLE
Fix OOM error while creating larger bitmap

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BackgroundImageLoaderAsync.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BackgroundImageLoaderAsync.java
@@ -6,9 +6,9 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Rect;
+import android.graphics.RectF;
 import android.graphics.drawable.BitmapDrawable;
 import android.view.ViewGroup;
 
@@ -97,56 +97,44 @@ public class BackgroundImageLoaderAsync extends GenericImageLoaderAsync
             return Math.max(xScaleFactor, yScaleFactor);
         }
 
-        // TODO: Optimize the rendering as drawBitmap source rectangle can scale images automatically
-        // Taken from here https://stackoverflow.com/questions/35276834/scale-bitmap-maintaining-aspect-ratio-and-fitting-both-width-and-height
         /**
          * Resizes the bitmap so the bitmap will completely fill the container where it is inserted
          * @param canvas
          */
-        private void resizeBitmapForCover(Canvas canvas)
-        {
+        private void resizeBitmapForCover(Canvas canvas) {
             Bitmap bitmap = m_bitmap;
             double originalWidth = bitmap.getWidth(), originalHeight = bitmap.getHeight();
             double scale = getScaleFactorForCover(canvas, bitmap);
 
-            int scaledWidth = (int)(scale * originalWidth);
-            int scaledHeight = (int)(scale * originalHeight);
-            Bitmap background = Bitmap.createBitmap(scaledWidth, scaledHeight, Bitmap.Config.ARGB_8888);
-            Canvas backgroundCanvas = new Canvas(background);
+            int canvasWidth = canvas.getWidth();
+            int canvasHeight = canvas.getHeight();
 
-            Matrix transformation = new Matrix();
-            transformation.preScale((float)scale, (float)scale);
-            Paint scaledImagePaint = new Paint();
-            scaledImagePaint.setFilterBitmap(true);
-            backgroundCanvas.drawBitmap(bitmap, transformation, scaledImagePaint);
+            float scaledWidth = (float) (scale * originalWidth);
+            float scaledHeight = (float) (scale * originalHeight);
 
             // canvasWidth <= scaledBitmapWidth and canvasHeight <= scaledBitmapHeight
-            int canvasWidth = canvas.getWidth(), canvasHeight = canvas.getHeight();
-            int origX = 0, origY = 0;
-            switch (m_backgroundImageProperties.GetHorizontalAlignment())
-            {
+            float origX = 0;
+            float origY = 0;
+            switch (m_backgroundImageProperties.GetHorizontalAlignment()) {
                 case Center:
-                    origX = (scaledWidth - canvasWidth) / 2;
+                    origX = (canvasWidth - scaledWidth) / 2;
                     break;
                 case Right:
-                    origX = scaledWidth - canvasWidth;
+                    origX = canvasWidth - scaledWidth;
                     break;
             }
 
-            switch (m_backgroundImageProperties.GetVerticalAlignment())
-            {
+            switch (m_backgroundImageProperties.GetVerticalAlignment()) {
                 case Center:
-                    origY = (scaledHeight - canvasHeight) / 2;
+                    origY = (canvasHeight - scaledHeight) / 2;
                     break;
                 case Bottom:
-                    origY = scaledHeight - canvasHeight;
+                    origY = canvasHeight - scaledHeight;
                     break;
             }
-
-            canvas.drawBitmap(background,
-                                new Rect(origX, origY, origX + canvasWidth, origY + canvasHeight),
-                                new Rect(0, 0, canvasWidth, canvasHeight),
-                                scaledImagePaint);
+            Paint scaledImagePaint = new Paint(Paint.FILTER_BITMAP_FLAG);
+            RectF destinationRect = new RectF(origX, origY, origX + scaledWidth, origY + scaledHeight);
+            canvas.drawBitmap(bitmap, null, destinationRect, scaledImagePaint);
         }
 
         private void tileHorizontally(Canvas canvas)


### PR DESCRIPTION
# Related Issue

Teams Android app crashes when using Adaptive Card backgroundImage with `fillMode=cover` on a very small size image . eg: 1x1 pixel.

# Description

This issue happens on a long Adaptive card with a small background image of size in few pixels and `fillMode=cover`.  Our QA team encountered this while stress testing the cards.

# Root Cause
Current code in `BackgroundImageLoaderAsync` calculates the scalingFactor when `fillMode=cover`. After calculating, it creates a new Bitmap of newly calculated dimensions before cropping it on the canvas. As the provided image is too small and card is too long, the new Bitmap exceeds Android's max allowed size of [150MB](https://android.googlesource.com/platform/frameworks/base.git/+/master/graphics/java/android/graphics/RecordingCanvas.java#43) causing OutOfMemory exception as seen in the stacktrace below.

eg: In this case, the created image was ~480MB in size.

```
FATAL EXCEPTION: main Process: com.microsoft.skype.teams.dev, PID: 27919
     at java.lang.RuntimeException: Canvas: trying to draw too large(486996624bytes) bitmap.  
     at  android.graphics.RecordingCanvas.throwIfCannotDraw(RecordingCanvas.java:267)
     at android.graphics.BaseRecordingCanvas.drawBitmap(BaseRecordingCanvas.java:98)
     at io.adaptivecards.renderer.BackgroundImageLoaderAsync
```

# Fix
Instead of creating a new Bitmap, we can pass newly calculated scaled coordinates and draw the background image on canvas accordingly.


# How Verified
- Tested locally on device before the fix. Was crashing 10/10
- After the fix, not crashing. Loading same cards multiple times and working as expected.
- Also tested Sample mobile app and verified different `fillModes` are loading the cards as expected.
