### PR TITLE
fix(ios): give the action overflow (…) button a descriptive accessible name

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOverflowRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOverflowRenderer.mm
@@ -37,6 +37,11 @@
                                          title:title
                                  andHostConfig:acoConfig];
 
+        // The visible glyph is "...", but VoiceOver would otherwise read the title
+        // literally ("dot dot dot"). Give the overflow control a descriptive, localized
+        // accessible name so screen-reader users know it reveals more options.
+        button.accessibilityLabel = NSLocalizedString(@"More options", nil);
+
         ACROverflowTarget *target;
         ACRTargetBuilderDirector *director = [rootView getActionsTargetBuilderDirector];
         ACRRenderingStatus status = buildTargetForButton(director, acoElem, button, &target);


### PR DESCRIPTION
## Summary
A card with more actions than fit on screen renders an overflow **\`\u2026\`** button. VoiceOver reads the literal title and announces **\"dot dot dot\"**, so screen-reader users do not know the control reveals more options. `ACRActionOverflowRenderer` builds the button with the visible glyph `...` as its title and never sets an `accessibilityLabel`.

## Change
`ACRActionOverflowRenderer.mm` \u2014 set a descriptive accessible name on the overflow button (visible glyph unchanged):

```objc
button.accessibilityLabel = NSLocalizedString(@\"More options\", nil);
```

`\"More options\"` is the established accessible label used elsewhere for this affordance, and `NSLocalizedString(@\"key\", nil)` follows the same pattern as the other strings in this SDK (e.g. `@\"card collapsed\"`, `@\"opens the date picker\"`).

## Accessibility evidence (before \u2192 after)
VoiceOver-equivalent element-tree dump for the same card:

| | overflow control `accessibilityLabel` |
|---|---|
| **Before** | `...` \u00d7 6, `More options` \u00d7 0 |
| **After** | `...` \u00d7 3 *(visible glyph text)* + **`More options` \u00d7 3** *(button names)* |

**Before** \u2014 overflow controls read `...`:
![before](https://github.com/hggzm/Teams-AdaptiveCards-Mobile/releases/download/a11y-evidence-batch1/ac-5536765-overflow-before.png)

**After** \u2014 boxes `[button] More options`; `...` remains only as static glyph text:
![after](https://github.com/hggzm/Teams-AdaptiveCards-Mobile/releases/download/a11y-evidence-batch1/ac-5536765-overflow-after.png)

## \u2753 Open question
This was surfaced while investigating an internal work item filed as a **focus-retention** issue on the overflow menu (\"focus not retained after activating Cancel under More(\u2026)\"). The concrete, reproducible defect found there is the **missing accessible name** on the overflow button, which this PR fixes. The focus-retention behavior may be a separate issue. **Should this PR stand on its own as the accessible-name fix, or would maintainers prefer it tracked/split differently?** Happy to adjust scope or split. See my comment below.
