### PR TITLE
fix(ios): keep interactive children reachable when a card has a selectAction

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
@@ -243,6 +243,18 @@ NSSet *unsupportedActionItems = [NSSet setWithArray:@[
     // renders background image for AdaptiveCard and an inner AdaptiveCard in a ShowCard
     renderBackgroundImage(backgroundImageProperties, verticalView, rootView);
 
+    // A card-level selectAction makes the whole card a single accessibility element
+    // (configureForSelectAction sets isAccessibilityElement = YES so the card and its
+    // subviews are read as one unit). When the card also has interactive children -
+    // action buttons or inputs - that collapse makes those controls unreachable for
+    // VoiceOver. Restore individual accessibility for the children while keeping a
+    // grouped reading order.
+    if (selectAction && verticalView.isAccessibilityElement &&
+        (!actions.empty() || inputs.count > 0)) {
+        verticalView.isAccessibilityElement = NO;
+        verticalView.shouldGroupAccessibilityChildren = YES;
+    }
+
     [rootView.context popCardContext:wrapperCard];
 
     return verticalView;


### PR DESCRIPTION
## Summary
A card that has a **card-level `selectAction`** and also contains interactive children (action buttons / inputs) collapses into a **single VoiceOver element**. The whole card is announced as one aggregated label and screen-reader users **cannot swipe to the individual controls** \u2014 every button and input is unreachable.

## Root cause
`ACRContentStackView configureForSelectAction` makes the container a single accessibility element so the select-action target reads as one unit:
```objc
// if there are no childs with select action,
// the current view becomes the accessibility element
// so it and its subviews become one unit.
if (!rootView.context.childHasSelectAction) {
    self.isAccessibilityElement = YES;
}
```
For a **root card** selectAction this runs before the body/actions are assembled, so it cannot account for interactive children and the entire card collapses.

## Change
`ACRRenderer.mm` \u2014 after the card is assembled, if it has a selectAction **and** interactive children, restore individual accessibility for the children while keeping a grouped reading order:
```objc
if (selectAction && verticalView.isAccessibilityElement &&
    (!actions.empty() || inputs.count > 0)) {
    verticalView.isAccessibilityElement = NO;
    verticalView.shouldGroupAccessibilityChildren = YES;
}
```
Scoped to the **root card** render path; cards with a selectAction but no interactive children are unchanged (still read as one unit).

## Accessibility evidence (before \u2192 after)
VoiceOver-equivalent element-tree dump for a card with a root `selectAction` and many `Action.Submit` buttons:

| | a11y tree |
|---|---|
| **Before** | **1 element** \u2014 the whole card, all controls unreachable |
| **After** | **40 elements** \u2014 14 buttons + 5 inputs + text, each individually reachable |

**Before** \u2014 entire card is one element:
![before](https://github.com/hggzm/Teams-AdaptiveCards-Mobile/releases/download/a11y-evidence-batch1/ac-5536935-tooltip-before.png)

**After** \u2014 every button / input / text is its own reachable element:
![after](https://github.com/hggzm/Teams-AdaptiveCards-Mobile/releases/download/a11y-evidence-batch1/ac-5536935-tooltip-after.png)

## \u2753 Open question (design tradeoff)
With this change the card-level `selectAction` is no longer a **directly focusable** VoiceOver element \u2014 focus goes to the children within a grouped region. Today the children are entirely unreachable, so this is a clear net improvement, but it does mean the card-level tap target is reachable through its children\u2019s grouped region rather than as its own element.

Exposing **both** (the card action as its own element **and** the children) would need a dedicated accessibility element for the card action. **Would maintainers prefer (1) this approach (children reachable + grouped), (2) a dedicated a11y element for the card action plus reachable children, or (3) something else?** Happy to adjust. See my comment below.
