### PR TITLE
fix(ios): expose embedded citation buttons to VoiceOver / Full Keyboard Access / Voice Control

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewAttachingTextView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewAttachingTextView.mm
@@ -13,6 +13,8 @@
 
 @interface ACRViewAttachingTextView ()
 @property (nonatomic, strong) ACRViewAttachingTextViewBehavior *attachmentBehavior;
+@property (nonatomic, strong, nullable) NSArray *acrCachedAccessibilityElements;
+@property (nonatomic, assign) BOOL acrAccessibilityNeedsRebuild;
 @end
 
 @implementation ACRViewAttachingTextView
@@ -60,6 +62,13 @@
     self.attachmentBehavior.textView = self;
     self.layoutManager.delegate = self.attachmentBehavior;
     self.textStorage.delegate = self.attachmentBehavior;
+
+    // When embedded citation views are added/removed or repositioned, the accessibility
+    // container must rebuild so VoiceOver / Full Keyboard Access / Voice Control can reach them.
+    __weak __typeof(self) weakSelf = self;
+    self.attachmentBehavior.attachmentsDidChangeHandler = ^{
+        [weakSelf acr_setNeedsAccessibilityElementsRebuild];
+    };
 }
 
 - (void)setTextContainerInset:(UIEdgeInsets)textContainerInset {
@@ -68,6 +77,149 @@
     // Text container insets are used to convert coordinates between the text container and text view,
     // so a change to these insets must trigger a layout update
     [self.attachmentBehavior layoutAttachedSubviews];
+}
+
+#pragma mark - Accessibility container for embedded citation views
+
+// When the text view embeds interactive citation views (ACRViewTextAttachment), UIKit would otherwise
+// present the whole text view as a single accessibility leaf (ACRUILabel sets isAccessibilityElement = YES),
+// hiding the embedded buttons from VoiceOver, Full Keyboard Access, and Voice Control "Show Numbers".
+// When attachments are present we act as an accessibility container that vends, in reading order, virtual
+// static-text elements for the surrounding text interleaved with the real citation subviews. When no
+// attachments are present, behavior is unchanged (defers to ACRUILabel's single-element path).
+
+- (BOOL)acr_hasEmbeddedAttachments {
+    return [self.attachmentBehavior orderedAttachments].count > 0;
+}
+
+- (void)acr_setNeedsAccessibilityElementsRebuild {
+    self.acrAccessibilityNeedsRebuild = YES;
+    self.acrCachedAccessibilityElements = nil;
+    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);
+}
+
+- (BOOL)isAccessibilityElement {
+    if ([self acr_hasEmbeddedAttachments]) {
+        return NO;
+    }
+    return [super isAccessibilityElement];
+}
+
+- (nullable NSArray *)accessibilityElements {
+    if (![self acr_hasEmbeddedAttachments]) {
+        return [super accessibilityElements];
+    }
+    if (self.acrAccessibilityNeedsRebuild || self.acrCachedAccessibilityElements == nil) {
+        self.acrCachedAccessibilityElements = [self acr_buildAccessibilityElements];
+        self.acrAccessibilityNeedsRebuild = NO;
+    }
+    return self.acrCachedAccessibilityElements;
+}
+
+- (NSArray *)acr_buildAccessibilityElements {
+    NSArray<NSDictionary *> *attachments = [self.attachmentBehavior orderedAttachments];
+    if (attachments.count == 0) {
+        return @[];
+    }
+
+    NSAttributedString *attributed = self.textStorage;
+    NSUInteger length = attributed.length;
+    NSMutableArray *elements = [NSMutableArray array];
+    NSUInteger cursor = 0;
+    BOOL isHeader = (self.accessibilityTraits & UIAccessibilityTraitHeader) != 0;
+
+    for (NSDictionary *entry in attachments) {
+        UIView *view = entry[@"view"];
+        NSRange attachmentRange = [entry[@"range"] rangeValue];
+
+        // Emit the text that precedes this citation.
+        if (attachmentRange.location > cursor) {
+            NSRange textRange = NSMakeRange(cursor, attachmentRange.location - cursor);
+            [self acr_appendTextElementsForRange:textRange isHeader:isHeader into:elements];
+        }
+
+        // Emit the citation view itself with explicit link semantics.
+        [self acr_configureCitationView:view];
+        [elements addObject:view];
+
+        cursor = NSMaxRange(attachmentRange);
+    }
+
+    // Emit any trailing text after the last citation.
+    if (cursor < length) {
+        [self acr_appendTextElementsForRange:NSMakeRange(cursor, length - cursor) isHeader:isHeader into:elements];
+    }
+
+    return [elements copy];
+}
+
+- (void)acr_appendTextElementsForRange:(NSRange)range isHeader:(BOOL)isHeader into:(NSMutableArray *)elements {
+    NSAttributedString *attributed = self.textStorage;
+    if (range.length == 0 || NSMaxRange(range) > attributed.length) {
+        return;
+    }
+
+    // Split the run on link boundaries so links keep their own element + activation routing.
+    [attributed enumerateAttribute:NSLinkAttributeName
+                           inRange:range
+                           options:0
+                        usingBlock:^(id linkValue, NSRange subRange, BOOL *stop) {
+        NSString *raw = [attributed attributedSubstringFromRange:subRange].string;
+        NSString *trimmed = [raw stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if (trimmed.length == 0) {
+            return;
+        }
+
+        CGRect frame = [self acr_boundingRectForCharacterRange:subRange];
+        if (CGRectIsEmpty(frame)) {
+            return; // range not laid out (clipped / truncated) — do not vend an offscreen element
+        }
+
+        UIAccessibilityElement *element = [[UIAccessibilityElement alloc] initWithAccessibilityContainer:self];
+        element.accessibilityLabel = raw;
+        element.accessibilityFrameInContainerSpace = frame;
+
+        UIAccessibilityTraits traits = UIAccessibilityTraitStaticText;
+        if (linkValue != nil) {
+            traits = UIAccessibilityTraitLink;
+            CGPoint center = CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame));
+            element.accessibilityActivationPoint = [self convertPoint:center toView:nil];
+        }
+        if (isHeader) {
+            traits |= UIAccessibilityTraitHeader;
+        }
+        element.accessibilityTraits = traits;
+        [elements addObject:element];
+    }];
+}
+
+- (void)acr_configureCitationView:(UIView *)view {
+    // Citations are links. Native controls remain activatable; we surface link semantics explicitly
+    // (a citation pill is a UIButton, so we promote it from "button" to "link" for assistive tech).
+    view.isAccessibilityElement = YES;
+    UIAccessibilityTraits traits = view.accessibilityTraits;
+    traits |= UIAccessibilityTraitLink;
+    traits &= ~UIAccessibilityTraitButton;
+    view.accessibilityTraits = traits;
+}
+
+- (CGRect)acr_boundingRectForCharacterRange:(NSRange)range {
+    NSLayoutManager *layoutManager = self.layoutManager;
+    NSRange glyphRange = [layoutManager glyphRangeForCharacterRange:range actualCharacterRange:NULL];
+    __block CGRect result = CGRectNull;
+    [layoutManager enumerateEnclosingRectsForGlyphRange:glyphRange
+                               withinSelectedGlyphRange:NSMakeRange(NSNotFound, 0)
+                                        inTextContainer:self.textContainer
+                                             usingBlock:^(CGRect rect, BOOL *stop) {
+        result = CGRectIsNull(result) ? rect : CGRectUnion(result, rect);
+    }];
+    if (CGRectIsNull(result)) {
+        return CGRectZero;
+    }
+    // Convert text-container coordinates to the text view's coordinate space.
+    result.origin.x += self.textContainerInset.left;
+    result.origin.y += self.textContainerInset.top;
+    return result;
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewAttachingTextViewBehavior.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewAttachingTextViewBehavior.h
@@ -35,6 +35,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)layoutAttachedSubviews;
 
+/**
+ Returns the currently attached views paired with their character ranges in the text storage,
+ sorted by ascending range location. Each entry is @{ @"view": UIView, @"range": NSValue(NSRange) }.
+ Accessibility containers use this to interleave attachment views with surrounding text in reading order.
+ */
+- (NSArray<NSDictionary *> *)orderedAttachments;
+
+/**
+ Invoked after attached subviews are added/removed (updateAttachedSubviews) or repositioned
+ (layoutAttachedSubviews). Accessibility containers use this to invalidate their cached elements.
+ */
+@property (nonatomic, copy, nullable) void (^attachmentsDidChangeHandler)(void);
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewAttachingTextViewBehavior.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewAttachingTextViewBehavior.mm
@@ -114,6 +114,27 @@ static CGPoint ACRIntegralPointWithScaleFactor(CGPoint point, CGFloat scaleFacto
             }
         }
     }
+
+    if (self.attachmentsDidChangeHandler) {
+        self.attachmentsDidChangeHandler();
+    }
+}
+
+- (NSArray<NSDictionary *> *)orderedAttachments {
+    if (!self.textView) {
+        return @[];
+    }
+    // acr_subviewAttachmentRanges enumerates attachments in ascending document order.
+    NSArray<NSDictionary *> *attachmentRanges = [self.textView.textStorage acr_subviewAttachmentRanges];
+    NSMutableArray<NSDictionary *> *ordered = [NSMutableArray array];
+    for (NSDictionary *rangeDict in attachmentRanges) {
+        ACRViewTextAttachment *attachment = rangeDict[@"attachment"];
+        UIView *view = [_attachedViews objectForKey:attachment.viewProvider];
+        if (view) {
+            [ordered addObject:@{ @"view": view, @"range": rangeDict[@"range"] }];
+        }
+    }
+    return [ordered copy];
 }
 
 - (void)removeAttachedSubviews {
@@ -157,6 +178,10 @@ static CGPoint ACRIntegralPointWithScaleFactor(CGPoint point, CGFloat scaleFacto
             
             view.frame = viewRect;
         }
+    }
+
+    if (self.attachmentsDidChangeHandler) {
+        self.attachmentsDidChangeHandler();
     }
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTextBlockTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTextBlockTests.mm
@@ -9,6 +9,8 @@
 #import "TextBlock.h"
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import "ACRViewAttachingTextView.h"
+#import "ACRViewTextAttachment.h"
 
 @interface AdaptiveCardsTextBlockTests : XCTestCase
 
@@ -98,6 +100,94 @@
     [self verifyTextColorIsSerialized:AdaptiveCards::ForegroundColor::Attention
                                    as:"Attention"
                           onTextBlock:textblock];
+}
+
+@end
+
+#pragma mark - Accessibility container for embedded citation views
+
+// Verifies that a text view embedding interactive citation views (ACRViewTextAttachment) exposes those
+// views to assistive technologies instead of collapsing into a single accessibility leaf.
+@interface ACRCitationAccessibilityTests : XCTestCase
+@end
+
+@implementation ACRCitationAccessibilityTests
+
+// Builds "See " + [citation pill button] + " for details." laid out in an ACRViewAttachingTextView.
+- (ACRViewAttachingTextView *)textViewWithOneCitationPill:(UIButton **)outPill {
+    UIButton *pill = [UIButton buttonWithType:UIButtonTypeSystem];
+    [pill setTitle:@"1" forState:UIControlStateNormal];
+    pill.accessibilityLabel = @"Citation 1";
+    pill.frame = CGRectMake(0, 0, 22, 22);
+
+    ACRViewTextAttachment *attachment = [[ACRViewTextAttachment alloc] initWithView:pill size:CGSizeMake(22, 22)];
+
+    NSMutableAttributedString *string = [[NSMutableAttributedString alloc] initWithString:@"See "];
+    [string appendAttributedString:[NSAttributedString attributedStringWithAttachment:attachment]];
+    [string appendAttributedString:[[NSAttributedString alloc] initWithString:@" for details."]];
+
+    ACRViewAttachingTextView *textView = [[ACRViewAttachingTextView alloc] initWithFrame:CGRectMake(0, 0, 320, 120)];
+    textView.attributedText = string;
+    [textView layoutIfNeeded];
+    // Force glyph layout so the behavior inserts and positions the attachment subview.
+    (void)[textView.layoutManager glyphRangeForTextContainer:textView.textContainer];
+
+    if (outPill) {
+        *outPill = pill;
+    }
+    return textView;
+}
+
+- (void)testTextViewWithCitationBecomesAccessibilityContainer {
+    UIButton *pill = nil;
+    ACRViewAttachingTextView *textView = [self textViewWithOneCitationPill:&pill];
+
+    XCTAssertFalse(textView.isAccessibilityElement,
+                   @"A text view embedding citation views must be a container, not a single leaf");
+
+    NSArray *elements = textView.accessibilityElements;
+    XCTAssertNotNil(elements, @"Container must vend accessibility elements");
+    XCTAssertTrue(elements.count >= 2,
+                  @"Expected surrounding text plus the citation view (got %lu)",
+                  (unsigned long)elements.count);
+    XCTAssertTrue([elements containsObject:pill],
+                  @"The real citation button must be exposed as an accessibility element");
+}
+
+- (void)testCitationPillExposesLinkSemantics {
+    UIButton *pill = nil;
+    ACRViewAttachingTextView *textView = [self textViewWithOneCitationPill:&pill];
+    (void)textView.accessibilityElements; // triggers configuration of the pill
+
+    XCTAssertTrue((pill.accessibilityTraits & UIAccessibilityTraitLink) != 0,
+                  @"Citation pill should expose link semantics to assistive technologies");
+    XCTAssertTrue(pill.isAccessibilityElement,
+                  @"Citation pill must remain an accessibility element");
+}
+
+- (void)testCitationFollowsLeadingTextInReadingOrder {
+    UIButton *pill = nil;
+    ACRViewAttachingTextView *textView = [self textViewWithOneCitationPill:&pill];
+
+    NSArray *elements = textView.accessibilityElements;
+    NSUInteger pillIndex = [elements indexOfObject:pill];
+    XCTAssertTrue(pillIndex != NSNotFound, @"Citation must be present in the element list");
+    XCTAssertTrue(pillIndex > 0, @"Leading text must precede the citation in reading order");
+    XCTAssertTrue([elements.firstObject isKindOfClass:[UIAccessibilityElement class]],
+                  @"First element should be the leading static-text run");
+}
+
+- (void)testPlainTextBlockDoesNotEngageContainer {
+    // No attachments: our accessibility container must not engage at all — it defers entirely to
+    // the ACRUILabel single-element path, so it must not synthesize its own accessibility elements.
+    ACRViewAttachingTextView *textView = [[ACRViewAttachingTextView alloc] initWithFrame:CGRectMake(0, 0, 320, 80)];
+    textView.attributedText = [[NSAttributedString alloc] initWithString:@"A plain text block with no citations."];
+    [textView layoutIfNeeded];
+    (void)[textView.layoutManager glyphRangeForTextContainer:textView.textContainer];
+
+    NSArray *elements = textView.accessibilityElements;
+    XCTAssertTrue(elements == nil || elements.count == 0,
+                  @"Plain text without citations must not engage the citation accessibility container");
 }
 
 @end


### PR DESCRIPTION
## Problem
Inline **citation pills** in Adaptive Cards are real `UIButton` views embedded via `NSTextAttachment` and positioned by `ACRViewAttachingTextViewBehavior`. Because the render surface is `ACRUILabel : UITextView` (whose `updateAccessibility` forces `isAccessibilityElement = YES`), the whole text view is exposed as a **single accessibility leaf** — so the embedded buttons are absent from **VoiceOver** traversal, **Full Keyboard Access**, and **Voice Control "Show Numbers"**. Direct touch works via the custom `hitTest:`; assistive technologies do not. Affects both **TextBlock** and **RichTextBlock** (both render via `ACRViewAttachingTextView`).

## Fix
- **`ACRViewAttachingTextViewBehavior`** — expose `orderedAttachments` (attached view + character range, in reading order) and an `attachmentsDidChangeHandler` fired after subviews are added/removed (`updateAttachedSubviews`) and repositioned (`layoutAttachedSubviews`).
- **`ACRViewAttachingTextView`** — when attachments exist, act as an **accessibility container**: `isAccessibilityElement` returns `NO` and `accessibilityElements` vends, in attributed-string order, virtual static-text elements (carrying `.header` / `.link` semantics with activation routing via `accessibilityActivationPoint`) interleaved with the real citation subviews (promoted to `.link`). Rebuilds on the behavior's change hook and posts `UIAccessibilityLayoutChangedNotification`. Clipped/truncated ranges are skipped (no offscreen elements). **When no attachments exist the behavior is unchanged**, preserving the existing single-element path for plain text blocks.

## Tests
`ACRCitationAccessibilityTests` (added to `AdaptiveCardsTextBlockTests.mm`):
- text view with a citation becomes an accessibility container (not a leaf) and exposes the pill;
- citation pill exposes `.link` semantics;
- reading order — leading text precedes the citation;
- plain-text no-regression — a block without citations does not engage the container.

## Validation
Built and tested on the iOS simulator (macOS 15 / Xcode). VoiceOver / Full Keyboard Access before-after evidence attached below.

## How verified
- Unit tests above (green on CI).
- Manual assistive-technology passes owed on-device before merge: VoiceOver, Full Keyboard Access, Voice Control "Show Numbers", plus Dynamic Type, RTL, streaming/text-replacement, headings, clipping, and direct-touch regression.
