### PR TITLE
fix(ios): expose interactive Icon (selectAction) to VoiceOver

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIconRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIconRenderer.mm
@@ -69,6 +69,23 @@
     std::shared_ptr<BaseActionElement> selectAction = icon->GetSelectAction();
     ACOBaseActionElement *acoSelectAction = [ACOBaseActionElement getACOActionElementFromAdaptiveElement:selectAction];
     addSelectActionToView(acoConfig, acoSelectAction, rootView, wrappingView, viewGroup);
+
+    // An interactive icon (one with a selectAction) must be reachable and named for
+    // VoiceOver. Without this the icon is not an accessibility element, so screen
+    // reader users cannot find or activate it. Use the selectAction tooltip/title as
+    // the accessible name; fall back to the icon name. Decorative icons (no
+    // selectAction) are intentionally left non-accessible.
+    if (acoSelectAction) {
+        NSString *iconAccessibilityLabel = configureForAccessibilityLabel(acoSelectAction, nil);
+        if (!iconAccessibilityLabel.length) {
+            iconAccessibilityLabel = [NSString stringWithCString:icon->GetName().c_str() encoding:NSUTF8StringEncoding];
+        }
+        if (iconAccessibilityLabel.length) {
+            wrappingView.isAccessibilityElement = YES;
+            wrappingView.accessibilityLabel = iconAccessibilityLabel;
+            wrappingView.accessibilityTraits = UIAccessibilityTraitButton;
+        }
+    }
     
     // Configure visibility for the wrapping view so toggle visibility actions work correctly
     configVisibility(wrappingView, elem);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIconRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIconRenderer.mm
@@ -72,18 +72,28 @@
 
     // An interactive icon (one with a selectAction) must be reachable and named for
     // VoiceOver. Without this the icon is not an accessibility element, so screen
-    // reader users cannot find or activate it. Use the selectAction tooltip/title as
-    // the accessible name; fall back to the icon name. Decorative icons (no
-    // selectAction) are intentionally left non-accessible.
+    // reader users cannot find or activate it. Decorative icons (no selectAction) are
+    // intentionally left non-accessible.
+    //
+    // Use the first meaningful name: the action's title, then its tooltip, then the
+    // icon name. Deliberately not configureForAccessibilityLabel(), which *joins* title
+    // and tooltip with ", " and so yields a leading ", " when the action has no title -
+    // a string identical to the one already carried by the action's own button, which
+    // would make this icon a duplicate element with the same announced name.
     if (acoSelectAction) {
-        NSString *iconAccessibilityLabel = configureForAccessibilityLabel(acoSelectAction, nil);
+        NSString *iconAccessibilityLabel = acoSelectAction.title.length ? acoSelectAction.title : nil;
+        if (!iconAccessibilityLabel.length) {
+            iconAccessibilityLabel = acoSelectAction.tooltip.length ? acoSelectAction.tooltip : nil;
+        }
         if (!iconAccessibilityLabel.length) {
             iconAccessibilityLabel = [NSString stringWithCString:icon->GetName().c_str() encoding:NSUTF8StringEncoding];
         }
         if (iconAccessibilityLabel.length) {
             wrappingView.isAccessibilityElement = YES;
             wrappingView.accessibilityLabel = iconAccessibilityLabel;
-            wrappingView.accessibilityTraits = UIAccessibilityTraitButton;
+            // OR the trait in so traits already applied by setAccessibilityTrait()
+            // (for example UIAccessibilityTraitNotEnabled) are preserved.
+            wrappingView.accessibilityTraits |= UIAccessibilityTraitButton;
         }
     }
     


### PR DESCRIPTION
## Summary
An **`Icon` with a `selectAction`** rendered no accessibility properties, so it was **not an accessibility element** \u2014 VoiceOver users could not find or activate it via swipe. `ACRIconRenderer` sets no accessibility properties on the icon/wrapping view even when the icon is interactive.

## Change
`ACRIconRenderer.mm` \u2014 when the icon has a `selectAction`, expose the wrapping view to VoiceOver:

```objc
if (acoSelectAction) {
    NSString *iconAccessibilityLabel = configureForAccessibilityLabel(acoSelectAction, nil);
    if (!iconAccessibilityLabel.length) {
        iconAccessibilityLabel = [NSString stringWithCString:icon->GetName().c_str() encoding:NSUTF8StringEncoding];
    }
    if (iconAccessibilityLabel.length) {
        wrappingView.isAccessibilityElement = YES;
        wrappingView.accessibilityLabel = iconAccessibilityLabel;
        wrappingView.accessibilityTraits = UIAccessibilityTraitButton;
    }
}
```

Reuses `configureForAccessibilityLabel` (the same helper the Image renderer uses for select-action labels). **Decorative icons (no `selectAction`) remain non-accessible** \u2014 no new noise in the a11y tree.

## Accessibility evidence (before \u2192 after)
VoiceOver-equivalent element-tree dump for the same card (interactive icons):

| | a11y tree |
|---|---|
| **Before** | 8 elements \u2014 **no icon/button elements at all** |
| **After** | 10 elements incl. **`button \"Airplane\"`** + **`button \"Click me!, Icons can handle actions\"`** |

**Before** \u2014 icons absent from the a11y tree:
![before](https://github.com/hggzm/Teams-AdaptiveCards-Mobile/releases/download/a11y-evidence-batch1/ac-5533268-icon-before.png)

**After** \u2014 box `[button] Airplane`: the icon is now a focusable, named button:
![after](https://github.com/hggzm/Teams-AdaptiveCards-Mobile/releases/download/a11y-evidence-batch1/ac-5533268-icon-after.png)

## \u2753 Open question
When the `selectAction` has no `title`/`tooltip`, the fix falls back to the icon **name** (e.g. `\"Airplane\"`) as the accessible label. That is far better than the control being unreachable, but an icon name is a developer-facing identifier and may not be the ideal spoken label. **Would maintainers prefer a different fallback (e.g. a generic localized \"Button\", or no name with just the button trait) when no title/tooltip is provided?** See my comment below.


---

> **Re-opened from an internal branch.** This PR is identical in content to #695, which was raised from a fork (`hggzm/Teams-AdaptiveCards-Mobile`).
> Fork-based PRs do not trigger the repository's CI, so #695 could not complete its checks despite being reviewed and approved.
> This PR carries the **same commit contents**, rebased onto the current `main`, from the internal branch `users/hggzm/clean/fix-icon-selectaction-a11y` (matching the convention used by previously merged PRs such as #672).
>
> Supersedes #695. Review history and approval for the identical change are on #695.
