### PR TITLE
docs: add descriptive comment to SharedAdaptiveCard.cpp

### DIFF
--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+// SharedAdaptiveCard: Core card model used by both iOS and Android renderers.
 #include "pch.h"
 #include "SharedAdaptiveCard.h"
 #include "ParseUtil.h"


### PR DESCRIPTION
Adds a one-line documentation comment describing the purpose of SharedAdaptiveCard.cpp  the core card model used by both iOS and Android renderers.

Cherry-picked from proxy/integration on hggzm/Teams-AdaptiveCards-Mobile (PR #14, commit 7bd23944).

Tracked in: https://github.com/hggzm/Teams-AdaptiveCards-Mobile/blob/proxy/integration/docs/PROXY_PR_LOG.md

---

> **Re-opened from an internal branch.** Identical in content to #508, which was raised from a fork (`hggzm/Teams-AdaptiveCards-Mobile`).
> Fork-based PRs do not trigger this repository's CI, so #508 could never complete its checks.
> This PR carries the **same change**, rebased onto current `main`, from the internal branch `users/hggzm/clean/add-shared-card-comment` (matching the convention used by previously merged PRs such as #672).
>
> Supersedes #508.
