### PR TITLE
Fix: TalkBack does not announce error messages on input validation failure

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/StretchableInputLayout.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/StretchableInputLayout.java
@@ -98,7 +98,8 @@ public class StretchableInputLayout extends StretchableElementLayout
     {
         addView(errorMessage);
         m_errorMessage = errorMessage;
-        m_errorMessage.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
+        // Fix: Allow TalkBack to announce error messages (#493)
+        m_errorMessage.setAccessibilityLiveRegion(View.ACCESSIBILITY_LIVE_REGION_POLITE);
     }
 
     public void setValidationResult(boolean isValid)
@@ -119,6 +120,12 @@ public class StretchableInputLayout extends StretchableElementLayout
             {
                 m_label.setContentDescription(m_label.getText() + " " + m_errorMessage.getText());
             }
+        }
+
+        // Fix: Announce error message to TalkBack when validation fails (#493)
+        if (!isValid && m_errorMessage != null && m_inputView != null)
+        {
+            m_inputView.announceForAccessibility(m_errorMessage.getText());
         }
     }
 }


### PR DESCRIPTION
## Problem
When input validation fails, error messages appear visually but TalkBack does not announce them, leaving screen reader users unaware of validation errors.

## Solution
Set ACCESSIBILITY_LIVE_REGION_POLITE on the error text view and call announceForAccessibility() when an error message is shown, so TalkBack automatically announces validation errors.

## Changes
- **StretchableInputLayout.java**: Added live region and announceForAccessibility for error messages

## Testing
- Verified with TalkBack on Android that error messages are announced when validation fails
- No impact on visual rendering or non-accessibility behavior

---

> **Re-opened from an internal branch.** Identical in content to #520, which was raised from a fork (`hggzm/Teams-AdaptiveCards-Mobile`).
> Fork-based PRs do not trigger this repository's CI, so #520 could never complete its checks.
> This PR carries the **same change**, rebased onto current `main`, from the internal branch `users/hggzm/clean/fix-error-message-accessibility` (matching the convention used by previously merged PRs such as #672).
>
> Supersedes #520.
