### PR TITLE
Fix: TalkBack aggregates all radio button labels when focusing RadioGroup

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
@@ -223,6 +223,10 @@ public class ChoiceSetInputRenderer extends BaseCardElementRenderer
         renderedCard.registerInputHandler(radioGroupInputHandler, renderArgs.getContainerCardId());
         InputUtils.updateInputHandlerInputWatcher(radioGroupInputHandler);
 
+        // Fix: Prevent RadioGroup from aggregating all child labels for TalkBack (#483)
+        // Each individual RadioButton should be announced separately
+        radioGroup.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+
         return radioGroup;
     }
 


### PR DESCRIPTION
## Problem
When TalkBack focuses on a RadioGroup in a ChoiceSet, it reads all child radio button labels concatenated together, creating a confusing and verbose announcement.

## Solution
Set IMPORTANT_FOR_ACCESSIBILITY_NO on the RadioGroup container so TalkBack skips the group and focuses directly on individual radio buttons.

## Changes
- **ChoiceSetInputRenderer.java**: Added IMPORTANT_FOR_ACCESSIBILITY_NO on RadioGroup

## Testing
- Verified with TalkBack on Android that individual radio buttons are focused separately
- Each radio button announces only its own label

---

> **Re-opened from an internal branch.** Identical in content to #522, which was raised from a fork (`hggzm/Teams-AdaptiveCards-Mobile`).
> Fork-based PRs do not trigger this repository's CI, so #522 could never complete its checks.
> This PR carries the **same change**, rebased onto current `main`, from the internal branch `users/hggzm/clean/fix-choiceset-group-labels` (matching the convention used by previously merged PRs such as #672).
>
> Supersedes #522.
