### PR TITLE
Fix: ShowCard toggle announces selected/not selected instead of expanded/collapsed

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseActionElementRenderer.java
@@ -332,7 +332,8 @@ public abstract class BaseActionElementRenderer implements IBaseActionElementRen
                 }
             }
 
-            v.setSelected(m_invisibleCard.getVisibility() != View.VISIBLE);
+            // Fix: Don't use setSelected() as it causes TalkBack to announce "selected/not selected" (#374)
+            // The expanded/collapsed state is announced via announceForAccessibility below
             // Reset all other buttons
             ViewGroup parentContainer;
             if (v.getTag(PARENT_DROPDOWN_TAG) != null)
@@ -363,6 +364,12 @@ public abstract class BaseActionElementRenderer implements IBaseActionElementRen
             }
 
             m_invisibleCard.setVisibility(m_invisibleCard.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+
+            // Fix: Announce expanded/collapsed state for TalkBack (#374)
+            boolean isExpanded = m_invisibleCard.getVisibility() == View.VISIBLE;
+            v.announceForAccessibility(v.getContentDescription() != null ?
+                v.getContentDescription() + (isExpanded ? " Expanded" : " Collapsed") :
+                (isExpanded ? "Expanded" : "Collapsed"));
 
             View mainCardView = ((ViewGroup) m_hiddenCardsLayout.getParent()).getChildAt(0);
             int padding = mainCardView.getPaddingTop();


### PR DESCRIPTION
## Problem
When toggling a ShowCard action, TalkBack announces "selected/not selected" instead of the more semantically correct "expanded/collapsed", which does not accurately convey the toggle behavior.

## Solution
Replaced setSelected() with announceForAccessibility() to explicitly announce "expanded" or "collapsed" state when toggling ShowCard visibility.

## Changes
- **BaseActionElementRenderer.java**: Replaced setSelected with announceForAccessibility for expanded/collapsed state

## Testing
- Verified with TalkBack on Android that ShowCard toggle announces "expanded" and "collapsed"
- Visual behavior remains unchanged

---

> **Re-opened from an internal branch.** Identical in content to #523, which was raised from a fork (`hggzm/Teams-AdaptiveCards-Mobile`).
> Fork-based PRs do not trigger this repository's CI, so #523 could never complete its checks.
> This PR carries the **same change**, rebased onto current `main`, from the internal branch `users/hggzm/clean/fix-showcard-toggle-a11y` (matching the convention used by previously merged PRs such as #672).
>
> Supersedes #523.
