### PR TITLE
fix(ios): prevent VoiceOver from announcing "Group" on containers with selectAction

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnRenderer.mm
@@ -153,7 +153,12 @@
     
     [column configureForSelectAction:acoSelectAction rootView:rootView];
 
-    column.shouldGroupAccessibilityChildren = YES;
+    // Only group children for accessibility when the column is not itself an accessibility element
+    // (i.e., when it does not have a selectAction). When a selectAction makes the column a
+    // single accessibility element, grouping causes VoiceOver to announce "Group" incorrectly.
+    if (!column.isAccessibilityElement) {
+        column.shouldGroupAccessibilityChildren = YES;
+    }
 
     NSString *areaName = stringForCString(elem->GetAreaGridName());
     [viewGroup addArrangedSubview:column withAreaName:areaName];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
@@ -819,6 +819,9 @@ using namespace AdaptiveCards;
             // so it and its subviews become one unit.
             if (!rootView.context.childHasSelectAction) {
                 self.isAccessibilityElement = YES;
+                // Prevent VoiceOver from announcing "Group" by ensuring
+                // the container is not treated as an accessibility group
+                self.shouldGroupAccessibilityChildren = NO;
             }
         }
     }


### PR DESCRIPTION
fix(ios): prevent VoiceOver from announcing "Group" on containers with selectAction

## Problem
When a container or column has a `selectAction` (e.g., `Action.OpenURL`), VoiceOver announces "Group" alongside the label. For example, "This Card's action will open a URL, **Group**" — the "Group" information is irrelevant and confusing.

## Root Cause
`ACRColumnRenderer` unconditionally sets `shouldGroupAccessibilityChildren = YES` on every column. When `configureForSelectAction` then sets `isAccessibilityElement = YES` (making the container a leaf accessibility node), the group trait still causes VoiceOver to announce "Group".

## Fix
- `ACRColumnRenderer.mm`: Only set `shouldGroupAccessibilityChildren = YES` when the column is **not** already an accessibility element (has no selectAction)
- `ACRContentStackView.mm`: Explicitly set `shouldGroupAccessibilityChildren = NO` when the view becomes a single accessibility element via selectAction

## Testing
- Navigate to any card with `Action.OpenURL` on a container
- VoiceOver should announce "This Card's action will open a URL, Link" without "Group"

Fixes #164


---

> **Re-opened from an internal branch.** Identical in content to #528, which was raised from a fork (`hggzm/Teams-AdaptiveCards-Mobile`).
> Fork-based PRs do not trigger this repository's CI, so #528 could never complete its checks.
> This PR carries the **same change**, rebased onto current `main`, from the internal branch `users/hggzm/clean/fix-group-announcement-164` (matching the convention used by previously merged PRs such as #672).
>
> Supersedes #528.
