### PR TITLE
fix(ios): announce "selected" state for ChoiceSet compact dropdown items

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
@@ -434,6 +434,11 @@ static inline CGRect ActiveSceneBoundsForView(UIView *view)
     cell.accessibilityValue = [NSString stringWithFormat:@"%ld of %ld", indexPath.row + 1, [self tableView:tableView numberOfRowsInSection:0]];
     cell.accessibilityIdentifier = [NSString stringWithFormat:@"%@, %@", self.id, cell.textLabel.text];
     cell.accessibilityTraits = UIAccessibilityTraitButton;
+    // Mark the currently selected item with the Selected trait so VoiceOver
+    // announces "selected" when the user navigates to it
+    if ([cell.textLabel.text isEqualToString:self.text]) {
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 


### PR DESCRIPTION
fix(ios): announce "selected" state for ChoiceSet compact dropdown items

## Problem
When navigating combo box dropdown items in VoiceOver, the screen reader only announces the item label and position (e.g., "Red color, 1 of 3") without indicating which item is currently selected.

## Root Cause
In `ACRChoiceSetCompactStyleView.mm`, the table cells for dropdown items are created with `UIAccessibilityTraitButton` but never include `UIAccessibilityTraitSelected` for the current selection.

Note: The expanded ChoiceSet style (`ACRChoiceSetViewDataSource.mm`) already handles this correctly at lines 145/152.

## Fix
After setting `UIAccessibilityTraitButton` on the cell, check if the cell text matches the current selection (`self.text`) and add `UIAccessibilityTraitSelected` if so.

## Testing
- Open any card with a compact ChoiceSet (combo box)
- Expand the dropdown
- VoiceOver should announce "Red color, 1 of 3, **selected**" for the active item

Fixes #173


---

> **Re-opened from an internal branch.** Identical in content to #529, which was raised from a fork (`hggzm/Teams-AdaptiveCards-Mobile`).
> Fork-based PRs do not trigger this repository's CI, so #529 could never complete its checks.
> This PR carries the **same change**, rebased onto current `main`, from the internal branch `users/hggzm/clean/fix-choiceset-selected-173` (matching the convention used by previously merged PRs such as #672).
>
> Supersedes #529.
