### PR TITLE
fix(android): preserve keyboard focusability for container children

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ContainerRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ContainerRenderer.java
@@ -440,10 +440,8 @@ public class ContainerRenderer extends BaseCardElementRenderer
                     View childView = group.getChildAt(0);
                     if (childView.isFocusable())
                     {
-                        childView.setFocusable(false);
-
-                        // setScreenReaderFocusable is only available in API level 28 (P) and above
-                        // Need to check the SDK version of the current device
+                        // Keep focusable for keyboard navigation but
+                        // mark as not important for TalkBack swipe (#105)
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
                         {
                             childView.setScreenReaderFocusable(false);


### PR DESCRIPTION
Fork-based PR (no Azure Pipelines CI). When ready for CI, push branch to upstream as `users/hggzm/clean/fix-container-child-a11y-105` and recreate.

History: upstream PRs #612 (closed)

## Summary
When a container had a `selectAction`, the renderer called `setFocusable(false)` on child views, completely removing them from the keyboard focus chain. TalkBack+keyboard users received irrelevant or missing information because the children couldn't be reached via keyboard navigation.

This fix was validated on the fork's CI pipeline via `proxy/fix-container-child-a11y-105` before creating this clean PR.

## Changes
- **ContainerRenderer.java**: Removed `childView.setFocusable(false)` from the selectAction child handling. Children still have `setScreenReaderFocusable(false)` and `IMPORTANT_FOR_ACCESSIBILITY_NO` for TalkBack swipe navigation, but they remain keyboard-focusable.

## Before
TalkBack+keyboard announces irrelevant information and skips child controls.

## After
TalkBack+keyboard correctly navigates to child controls and announces their content.

## Testing
1. Open a card with a container that has a selectAction (e.g. Stock Update)
2. Enable TalkBack with an external keyboard
3. Navigate using Tab/Shift+Tab and arrow keys
4. Verify child elements are reachable and announced correctly
5. Verify swipe navigation still treats the container as a single unit

---

> **Re-opened from an internal branch.** Identical in content to #643, which was raised from a fork (`hggzm/Teams-AdaptiveCards-Mobile`).
> Fork-based PRs do not trigger this repository's CI, so #643 could never complete its checks.
> This PR carries the **same change**, rebased onto current `main`, from the internal branch `users/hggzm/clean/fix-container-child-a11y-105` (matching the convention used by previously merged PRs such as #672).
>
> Supersedes #643.
