### PR TITLE
[Release] AdaptiveCards iOS SDK v2.11.18

### DIFF
--- a/source/ios/tools/AdaptiveCards.podspec
+++ b/source/ios/tools/AdaptiveCards.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'AdaptiveCards'
 
-  spec.version          = '2.11.9'
+  spec.version          = '2.11.18'
 
   spec.license          = { :type => 'Adaptive Cards Binary EULA', :file => 'source/EULA-Non-Windows.txt' } 
 


### PR DESCRIPTION
## Summary

Version bump of the AdaptiveCards iOS pod to **2.11.18**.

Single-line change to `source/ios/tools/AdaptiveCards.podspec`. No source changes in this PR.

## Why 2.11.18 and not 2.11.10

CocoaPods resolves by SEMVER, not by publish date. Trunk currently holds an out-of-band
`2.11.17` (published 2026-04-04) that is higher than the current line `2.11.9`
(published 2026-07-14). Publishing `2.11.10` would sort BELOW `2.11.17`, so:

* trunk's "latest" would remain `2.11.17`
* `pod outdated` would keep reporting incorrectly
* any consumer on `~> 2.11` would never receive the fixes below

`2.11.18` restores a correct ordering. Neither `2.11.10` nor `2.11.18` exists on trunk today.

## What ships in 2.11.18

Everything merged to `main` since tag `iOS/adaptivecards-ios@2.11.9` (`8f36f5c27`).
Range `8f36f5c27..da1c696fa` is 10 files, +428 / -43.

### iOS accessibility fixes

| PR | File | Fix |
|----|------|-----|
| #700 | `ACRActionOverflowRenderer.mm` | overflow `...` button gets a localized accessible name |
| #701 | `ACRIconRenderer.mm` | interactive Icon (`selectAction`) exposed to VoiceOver, named by title/tooltip |
| #702 | `ACRRenderer.mm` | interactive children stay reachable when the card itself has a `selectAction` |
| #703 | `ACRViewAttachingTextView.mm`, `ACRViewAttachingTextViewBehavior.{h,mm}` | embedded citation buttons exposed to VoiceOver / Full Keyboard Access / Voice Control |

Tests: `AdaptiveCardsTextBlockTests.mm` (+90), `ADCIOSVisualizerUITests.mm` (+8/-4).

### Shared ObjectModel (C++) fix

| PR | File | Fix |
|----|------|-----|
| #698 | `shared/cpp/ObjectModel/AdaptiveBase64Util.cpp`, `Base64Test.cpp` | harden unsafe AdaptiveBase64 decode handling |

Note: #698 lives in the shared C++ ObjectModel, so it affects **both** iOS and Android.
The Android CI leg on this PR is therefore load-bearing and should not be dismissed as
infra without evidence.

## Public API

No public API breaks.

## Verification

Relies on `teams-adaptivecards-ios-pr` and `teams-adaptivecards-android-pr`.
A podspec version bump cannot change behaviour on its own, so these runs act as a
regression check on the already-merged content listed above.

## Follow-up (not part of this PR)

`teams-adaptivecards-ios-release` (the trunk publish pipeline, `.pipelines/ios-release.yml`)
appears stale and will likely fail if queued as-is:

1. `vmImage: internal-macos-10.15` is a retired image.
2. It runs `pod trunk push ./source/ios/AdaptiveCards.podspec`, a path that does not exist.
   The real podspec is `source/ios/tools/AdaptiveCards.podspec` (the repo-root
   `AdaptiveCards.podspec` is a symlink added in 80b046747).

Its last successful run was #2658 on 2025-04-17; 2.11.8 / 2.11.9 / 2.11.17 were all
published manually. Repairing that pipeline would make future releases fully headless.
