### PR TITLE
fix(ci): repair teams-adaptivecards-ios-release so trunk publish can actually run

### DIFF
--- a/.pipelines/ios-release.yml
+++ b/.pipelines/ios-release.yml
@@ -5,7 +5,7 @@ trigger: none
 
 pool:
   name: Azure Pipelines
-  vmImage: internal-macos-10.15
+  vmImage: macos-latest
 
 variables:
 - group: AdaptiveCards-KVLink
@@ -58,6 +58,6 @@ steps:
   displayName: Push To cocoapods
   inputs:
     targetType: inline
-    script: "cat ./source/ios/AdaptiveCards.podspec\nif type brew >/dev/null 2>&1;\nthen \n   brew upgrade cocoapods >/dev/null 2>&1; \n   brew install cocoapods >/dev/null 2>&1; \nfi\n\npod trunk push  ./source/ios/AdaptiveCards.podspec\n"
+    script: "cat ./source/ios/tools/AdaptiveCards.podspec\nif type brew >/dev/null 2>&1;\nthen \n   brew upgrade cocoapods >/dev/null 2>&1; \n   brew install cocoapods >/dev/null 2>&1; \nfi\n\npod trunk push ./source/ios/tools/AdaptiveCards.podspec --allow-warnings\n"
   env:
     COCOAPODS_TRUNK_TOKEN: $(cocoapod-trunk-token)


### PR DESCRIPTION
> **DRAFT / UNVERIFIED.** This pipeline cannot be dry-run: queueing it *is* a
> CocoaPods trunk publish. Every claim below is from static evidence in this repo and
> from ADO run history, not from a successful execution. Please review before merging.

## Problem

`teams-adaptivecards-ios-release` (ADO `DomoreexpGithub` build definition **#35**,
yaml `.pipelines/ios-release.yml`) is the pipeline that is supposed to publish the
iOS pod to CocoaPods trunk. It cannot succeed in its current state.

Evidence:

1. **Its `Push To cocoapods` step has never executed.** The most recent run of
   definition #35 is **#2658, 2025-04-17**, on branch
   `releases/feature/SplitButton_Add_ShowCard_Support`. Its timeline contains only
   `Initialize job` / `Checkout` / `Xcode build` / `Component Detection` /
   `Secure Supply Chain Analysis` / post-job / `Finalize Job`. No `DownloadSecureFile`,
   no `dotnet` steps, no `Push To cocoapods`. So the publish path carries no
   validation history at all.

2. **The podspec path does not exist.** The step runs
   `cat ./source/ios/AdaptiveCards.podspec` and
   `pod trunk push ./source/ios/AdaptiveCards.podspec`. The only two podspecs in the
   tree are `AdaptiveCards.podspec` (a symlink, added in `80b046747`) and
   `source/ios/tools/AdaptiveCards.podspec`. There is no `source/ios/AdaptiveCards.podspec`.
   `.pipelines/templates/ios-spec-lint-template.yml` already uses the correct path.

3. **`vmImage: internal-macos-10.15` is the only stale image left in the repo.**
   Every other iOS pipeline here (`ios-ci.yml`, `ios-app-push.yml`, `ios-heartbeat.yml`)
   uses `vmImage: 'macos-latest'`.

Consistent with the above: the last three trunk publishes (2.11.8, 2.11.9 and the
out-of-band 2.11.17) were all done manually under the `Joseph Woo` trunk account, not
by this pipeline.

## Change

Two lines in `.pipelines/ios-release.yml`:

| | before | after |
|---|---|---|
| pool image | `internal-macos-10.15` | `macos-latest` (matches `ios-ci.yml`) |
| podspec path | `./source/ios/AdaptiveCards.podspec` | `./source/ios/tools/AdaptiveCards.podspec` (matches the spec-lint template) |
| trunk push flags | none | `--allow-warnings` (matches `pod spec lint --allow-warnings` in the spec-lint template, which implies the spec does emit warnings) |

## Safety

`.pipelines/ios-release.yml` is `trigger: none` + `pr: none`. Merging this PR cannot
publish anything by itself; the pipeline only runs when someone deliberately queues it.

## What is still unverified

* whether `Xcode build` of scheme `AdaptiveCards-Universal` still succeeds on `macos-latest`
* whether the `AdaptiveCards-KVLink` variable group and `cocoapod-trunk-token` secret are still valid
* whether secure file `8bf566e4-a21c-48b4-90e5-368f3adaef68` and the `IOSFeed` dotnet project still work

All three fail *before* the trunk push, so the failure mode is safe (no partial publish).

## Why now

This blocks the v2.11.18 release (#717). With this merged, an iOS release becomes fully
headless: merge the version bump, tag, then queue definition #35 on the tag.
