### PR TITLE
ios: add thread safe text data

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRFactSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRFactSetRenderer.mm
@@ -53,8 +53,7 @@
     NSMutableAttributedString *content = nil;
     if (rootView) {
         std::shared_ptr<FactSet> fctSet = std::dynamic_pointer_cast<FactSet>(element);
-        NSMutableDictionary *textMap = [rootView getTextMap];
-        NSDictionary *data = textMap[elementId];
+        NSDictionary *data = [rootView textDataForElementId:elementId];
         NSData *htmlData = data[@"html"];
         NSDictionary *options = data[@"options"];
         NSDictionary *descriptor = data[@"descriptor"];
@@ -130,7 +129,6 @@
     [factSetWrapperView addArrangedSubview:valueStack];
     [ACRSeparator renderSeparationWithFrame:CGRectMake(0, 0, factSetConfig.spacing, factSetConfig.spacing) superview:factSetWrapperView axis:UILayoutConstraintAxisHorizontal];
 
-    NSMutableDictionary *textMap = [rootView getTextMap];
     NSInteger nValidFacts = 0;
 
     NSMutableArray *accessibilityElements = [[NSMutableArray alloc] init];
@@ -138,7 +136,7 @@
     for (auto fact : factSet->GetFacts()) {
         NSString *title = [NSString stringWithCString:fact->GetTitle().c_str() encoding:NSUTF8StringEncoding];
         NSString *titleElemId = [key stringByAppendingString:[[NSNumber numberWithInt:rowFactId++] stringValue]];
-        if (![textMap objectForKey:titleElemId]) {
+        if (![rootView textDataForElementId:titleElemId]) {
             RichTextElementProperties titleTextProp{factSetConfig.title, fact->GetTitle(), fact->GetLanguage()};
             buildIntermediateResultForText(rootView, acoConfig, titleTextProp, titleElemId);
         }
@@ -163,7 +161,7 @@
         }
         NSString *value = [NSString stringWithCString:fact->GetValue().c_str() encoding:NSUTF8StringEncoding];
         NSString *valElemId = [key stringByAppendingString:[[NSNumber numberWithInt:rowFactId++] stringValue]];
-        if (![textMap objectForKey:valElemId]) {
+        if (![rootView textDataForElementId:valElemId]) {
             RichTextElementProperties valueTextProp{factSetConfig.value, fact->GetValue(), fact->GetLanguage()};
             buildIntermediateResultForText(rootView, acoConfig, valueTextProp, valElemId);
         }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
@@ -45,7 +45,7 @@
 
 - (NSMutableDictionary *)getTextMap;
 
-// Returns the current text preprocessing result using synchronized access.
+// Returns nil for a nil or missing element ID. Do not call from the internal text-processing queue.
 - (NSDictionary *)textDataForElementId:(NSString *)elementId;
 
 - (ACOAdaptiveCard *)card;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
@@ -45,6 +45,9 @@
 
 - (NSMutableDictionary *)getTextMap;
 
+// Returns the current text preprocessing result using synchronized access.
+- (NSDictionary *)textDataForElementId:(NSString *)elementId;
+
 - (ACOAdaptiveCard *)card;
 
 - (UIView *)render;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -667,7 +667,7 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
         return nil;
     }
 
-    __block NSDictionary *data;
+    __block NSDictionary *data = nil;
     dispatch_sync(_serial_text_queue, ^{
         data = self->_textMap[elementId];
     });

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -661,6 +661,19 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
     return _textMap;
 }
 
+- (NSDictionary *)textDataForElementId:(NSString *)elementId
+{
+    if (elementId == nil) {
+        return nil;
+    }
+
+    __block NSDictionary *data;
+    dispatch_sync(_serial_text_queue, ^{
+        data = self->_textMap[elementId];
+    });
+    return data;
+}
+
 - (ACOAdaptiveCard *)card
 {
     return _adaptiveCard;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTests.mm
@@ -8,15 +8,43 @@
 #import "ACOBaseCardElementPrivate.h"
 #import "ACRBaseCardElementRenderer.h"
 #import "ACRContentHoldingUIView.h"
+#import "ACRFactSetRenderer.h"
 #import "ACRInputLabelView.h"
 #import "ACRRegistration.h"
 #import "ACRTextView.h"
+#import "ACRViewPrivate.h"
+#import "Fact.h"
+#import "FactSet.h"
 #import "TextBlock.h"
 #import "TextInput.h"
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
 using namespace AdaptiveCards;
+
+@interface ACRTrackingTextMapView : ACRView
+
+@property NSUInteger liveTextMapAccessCount;
+@property NSUInteger enqueueCount;
+
+@end
+
+@implementation ACRTrackingTextMapView
+
+- (NSMutableDictionary *)getTextMap
+{
+    self.liveTextMapAccessCount++;
+    return [super getTextMap];
+}
+
+- (void)enqueueIntermediateTextProcessingResult:(NSDictionary *)data
+                                      elementId:(NSString *)elementId
+{
+    self.enqueueCount++;
+    [super enqueueIntermediateTextProcessingResult:data elementId:elementId];
+}
+
+@end
 
 @interface AdaptiveCardsTests : XCTestCase
 
@@ -126,6 +154,87 @@ using namespace AdaptiveCards;
     XCTAssertTrue([labelview.inputView isKindOfClass:[UITextField class]]);
     UITextField *textField = (UITextField *)labelview.inputView;
     XCTAssertTrue(textField.isSecureTextEntry);
+}
+
+- (std::shared_ptr<FactSet>)factSetWithTitle:(std::string const &)title
+                                      value:(std::string const &)value
+{
+    std::shared_ptr<FactSet> factSet = std::make_shared<FactSet>();
+    factSet->GetFacts().push_back(std::make_shared<Fact>(title, value));
+    return factSet;
+}
+
+- (UIView *)renderFactSet:(std::shared_ptr<FactSet> const &)factSet
+                 rootView:(ACRView *)rootView
+{
+    ACOBaseCardElement *baseCardElement = [[ACOBaseCardElement alloc] initWithBaseCardElement:factSet];
+    ACRColumnView *viewGroup = [[ACRColumnView alloc] init];
+    ACOHostConfig *config = [[ACOHostConfig alloc] init];
+
+    return [[ACRFactSetRenderer getInstance] render:viewGroup
+                                           rootView:rootView
+                                             inputs:[[NSMutableArray alloc] init]
+                                    baseCardElement:baseCardElement
+                                         hostConfig:config];
+}
+
+- (void)testFactSetRendererUsesSynchronizedTextDataAccessor
+{
+    ACRTrackingTextMapView *rootView = [[ACRTrackingTextMapView alloc] init];
+    std::shared_ptr<FactSet> factSet = [self factSetWithTitle:"Title" value:"Value"];
+
+    UIView *renderedView = [self renderFactSet:factSet rootView:rootView];
+
+    XCTAssertNotNil(renderedView);
+    XCTAssertEqual(rootView.liveTextMapAccessCount, 0);
+    XCTAssertEqual(rootView.enqueueCount, 2);
+    XCTAssertEqualObjects([rootView textDataForElementId:@"*0"][@"nonhtml"], @"Title");
+    XCTAssertEqualObjects([rootView textDataForElementId:@"*1"][@"nonhtml"], @"Value");
+}
+
+- (void)testFactSetRendererUsesExistingPreprocessedTextData
+{
+    ACRTrackingTextMapView *rootView = [[ACRTrackingTextMapView alloc] init];
+    NSDictionary *titleData = @{@"nonhtml" : @"Preprocessed title",
+                                @"descriptor" : @{NSFontAttributeName : [UIFont systemFontOfSize:12]}};
+    NSDictionary *valueData = @{@"nonhtml" : @"Preprocessed value",
+                                @"descriptor" : @{NSFontAttributeName : [UIFont systemFontOfSize:12]}};
+    [rootView enqueueIntermediateTextProcessingResult:titleData elementId:@"*0"];
+    [rootView enqueueIntermediateTextProcessingResult:valueData elementId:@"*1"];
+    rootView.enqueueCount = 0;
+
+    UIView *renderedView = [self renderFactSet:[self factSetWithTitle:"Title" value:"Value"]
+                                     rootView:rootView];
+
+    XCTAssertNotNil(renderedView);
+    XCTAssertEqual(rootView.liveTextMapAccessCount, 0);
+    XCTAssertEqual(rootView.enqueueCount, 0);
+    XCTAssertEqualObjects([rootView textDataForElementId:@"*0"], titleData);
+    XCTAssertEqualObjects([rootView textDataForElementId:@"*1"], valueData);
+}
+
+- (void)testFactSetRendererSupportsConcurrentTextMapWrites
+{
+    ACRTrackingTextMapView *rootView = [[ACRTrackingTextMapView alloc] init];
+    dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+    dispatch_group_t group = dispatch_group_create();
+
+    for (NSInteger index = 0; index < 500; index++) {
+        dispatch_group_async(group, queue, ^{
+            NSString *key = [NSString stringWithFormat:@"background-%ld", (long)index];
+            [rootView enqueueIntermediateTextProcessingResult:@{@"nonhtml" : key} elementId:key];
+        });
+    }
+
+    for (NSInteger index = 0; index < 25; index++) {
+        UIView *renderedView = [self renderFactSet:[self factSetWithTitle:"**Title**" value:"**Value**"]
+                                         rootView:rootView];
+        XCTAssertNotNil(renderedView);
+    }
+
+    XCTAssertEqual(dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC)), 0);
+    XCTAssertEqual(rootView.liveTextMapAccessCount, 0);
+    XCTAssertEqualObjects([rootView textDataForElementId:@"background-499"][@"nonhtml"], @"background-499");
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTests.mm
@@ -219,10 +219,12 @@ using namespace AdaptiveCards;
     dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
     dispatch_group_t group = dispatch_group_create();
 
-    for (NSInteger index = 0; index < 500; index++) {
+    for (NSInteger worker = 0; worker < 4; worker++) {
         dispatch_group_async(group, queue, ^{
-            NSString *key = [NSString stringWithFormat:@"background-%ld", (long)index];
-            [rootView enqueueIntermediateTextProcessingResult:@{@"nonhtml" : key} elementId:key];
+            for (NSInteger iteration = 0; iteration < 50; iteration++) {
+                NSString *key = [NSString stringWithFormat:@"background-%ld-%ld", (long)worker, (long)iteration];
+                [rootView enqueueIntermediateTextProcessingResult:@{@"nonhtml" : key} elementId:key];
+            }
         });
     }
 
@@ -234,7 +236,7 @@ using namespace AdaptiveCards;
 
     XCTAssertEqual(dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC)), 0);
     XCTAssertEqual(rootView.liveTextMapAccessCount, 0);
-    XCTAssertEqualObjects([rootView textDataForElementId:@"background-499"][@"nonhtml"], @"background-499");
+    XCTAssertEqualObjects([rootView textDataForElementId:@"background-3-49"][@"nonhtml"], @"background-3-49");
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTextBlockTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTextBlockTests.mm
@@ -109,22 +109,57 @@
     ACRView *rootView = [[ACRView alloc] initWithFrame:CGRectZero];
     dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
     dispatch_group_t group = dispatch_group_create();
+    NSMutableArray<NSString *> *failures = [[NSMutableArray alloc] init];
 
-    for (NSInteger index = 0; index < 500; index++) {
-        NSString *key = [NSString stringWithFormat:@"text-%ld", (long)index];
-        NSDictionary *data = @{@"nonhtml" : key};
+    for (NSInteger worker = 0; worker < 4; worker++) {
+        dispatch_group_async(group, queue, ^{
+            for (NSInteger iteration = 0; iteration < 50; iteration++) {
+                NSString *key = [NSString stringWithFormat:@"text-%ld-%ld", (long)worker, (long)iteration];
+                NSDictionary *data = @{@"nonhtml" : key};
 
-        dispatch_group_async(group, queue, ^{
-            [rootView enqueueIntermediateTextProcessingResult:data elementId:key];
-        });
-        dispatch_group_async(group, queue, ^{
-            (void)[rootView textDataForElementId:key];
+                [rootView enqueueIntermediateTextProcessingResult:data elementId:key];
+                NSString *observedValue = [rootView textDataForElementId:key][@"nonhtml"];
+                if (![observedValue isEqualToString:key]) {
+                    @synchronized(failures) {
+                        [failures addObject:[NSString stringWithFormat:@"%@ returned %@", key, observedValue]];
+                    }
+                }
+            }
         });
     }
 
     XCTAssertEqual(dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC)), 0);
-    XCTAssertEqualObjects([rootView textDataForElementId:@"text-0"][@"nonhtml"], @"text-0");
-    XCTAssertEqualObjects([rootView textDataForElementId:@"text-499"][@"nonhtml"], @"text-499");
+    XCTAssertEqual(failures.count, 0, @"Concurrent lookup failures: %@", failures);
+}
+
+- (void)testTextMapSupportsConcurrentHotKeyOverwrites
+{
+    ACRView *rootView = [[ACRView alloc] initWithFrame:CGRectZero];
+    dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+    dispatch_group_t group = dispatch_group_create();
+    NSMutableArray<NSString *> *failures = [[NSMutableArray alloc] init];
+    NSString *hotKey = @"hot-key";
+
+    [rootView enqueueIntermediateTextProcessingResult:@{@"nonhtml" : @"hot-0"} elementId:hotKey];
+
+    for (NSInteger worker = 0; worker < 4; worker++) {
+        dispatch_group_async(group, queue, ^{
+            for (NSInteger iteration = 0; iteration < 25; iteration++) {
+                NSString *value = [NSString stringWithFormat:@"hot-%ld-%ld", (long)worker, (long)iteration];
+                [rootView enqueueIntermediateTextProcessingResult:@{@"nonhtml" : value} elementId:hotKey];
+
+                NSString *observedValue = [rootView textDataForElementId:hotKey][@"nonhtml"];
+                if (![observedValue hasPrefix:@"hot-"]) {
+                    @synchronized(failures) {
+                        [failures addObject:observedValue ?: @"nil"];
+                    }
+                }
+            }
+        });
+    }
+
+    XCTAssertEqual(dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC)), 0);
+    XCTAssertEqual(failures.count, 0, @"Invalid hot-key values: %@", failures);
 }
 
 - (void)testTextDataForElementIdReturnsStoredData

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTextBlockTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTextBlockTests.mm
@@ -9,6 +9,8 @@
 #import "TextBlock.h"
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import "ACRView.h"
+#import "ACRViewPrivate.h"
 #import "ACRViewAttachingTextView.h"
 #import "ACRViewTextAttachment.h"
 
@@ -100,6 +102,47 @@
     [self verifyTextColorIsSerialized:AdaptiveCards::ForegroundColor::Attention
                                    as:"Attention"
                           onTextBlock:textblock];
+}
+
+- (void)testTextMapSupportsConcurrentReadsAndWrites
+{
+    ACRView *rootView = [[ACRView alloc] initWithFrame:CGRectZero];
+    dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+    dispatch_group_t group = dispatch_group_create();
+
+    for (NSInteger index = 0; index < 500; index++) {
+        NSString *key = [NSString stringWithFormat:@"text-%ld", (long)index];
+        NSDictionary *data = @{@"nonhtml" : key};
+
+        dispatch_group_async(group, queue, ^{
+            [rootView enqueueIntermediateTextProcessingResult:data elementId:key];
+        });
+        dispatch_group_async(group, queue, ^{
+            (void)[rootView textDataForElementId:key];
+        });
+    }
+
+    XCTAssertEqual(dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC)), 0);
+    XCTAssertEqualObjects([rootView textDataForElementId:@"text-0"][@"nonhtml"], @"text-0");
+    XCTAssertEqualObjects([rootView textDataForElementId:@"text-499"][@"nonhtml"], @"text-499");
+}
+
+- (void)testTextDataForElementIdReturnsStoredData
+{
+    ACRView *rootView = [[ACRView alloc] initWithFrame:CGRectZero];
+    NSDictionary *expectedData = @{@"nonhtml" : @"expected"};
+
+    [rootView enqueueIntermediateTextProcessingResult:expectedData elementId:@"text"];
+
+    XCTAssertEqualObjects([rootView textDataForElementId:@"text"], expectedData);
+}
+
+- (void)testTextDataForElementIdReturnsNilForMissingOrNilKey
+{
+    ACRView *rootView = [[ACRView alloc] initWithFrame:CGRectZero];
+
+    XCTAssertNil([rootView textDataForElementId:@"missing"]);
+    XCTAssertNil([rootView textDataForElementId:nil]);
 }
 
 @end


### PR DESCRIPTION
# Description

Adds a thread-safe API for retrieving preprocessed text data from `ACRView`.

`ACRView` stores text preprocessing results in a shared mutable dictionary. Writes are serialized through `_serial_text_queue`, while callers retrieving the live dictionary through `getTextMap` cannot coordinate individual reads with background preprocessing.

This change adds `textDataForElementId:`. The accessor reads the requested entry on the same serial queue used by writers, allowing consumers to safely retrieve text data without changing the existing `getTextMap` contract or SDK renderer behavior.

The change is intentionally narrow and preserves existing API semantics.

# Sample Card

```json
{
  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
  "type": "AdaptiveCard",
  "version": "1.5",
  "body": [
    {
      "type": "Container",
      "items": [
        {
          "type": "RichTextBlock",
          "inlines": [
            { "type": "TextRun", "text": "Rich text 01 with background preprocessing. " },
            { "type": "TextRun", "text": "Rich text 02 with background preprocessing. ", "weight": "Bolder" },
            { "type": "TextRun", "text": "Rich text 03 with background preprocessing. " },
            { "type": "TextRun", "text": "Rich text 04 with background preprocessing. ", "italic": true },
            { "type": "TextRun", "text": "Rich text 05 with background preprocessing. " },
            { "type": "TextRun", "text": "Rich text 06 with background preprocessing. ", "weight": "Bolder" },
            { "type": "TextRun", "text": "Rich text 07 with background preprocessing. " },
            { "type": "TextRun", "text": "Rich text 08 with background preprocessing. ", "italic": true },
            { "type": "TextRun", "text": "Rich text 09 with background preprocessing. " },
            { "type": "TextRun", "text": "Rich text 10 with background preprocessing. ", "weight": "Bolder" },
            { "type": "TextRun", "text": "Rich text 11 with background preprocessing. " },
            { "type": "TextRun", "text": "Rich text 12 with background preprocessing. ", "italic": true }
          ]
        },
        {
          "type": "FactSet",
          "facts": [
            { "title": "Fact 01", "value": "Value with **markdown** and https://example.com/01" },
            { "title": "Fact 02", "value": "Value with **markdown** and https://example.com/02" },
            { "title": "Fact 03", "value": "Value with **markdown** and https://example.com/03" },
            { "title": "Fact 04", "value": "Value with **markdown** and https://example.com/04" },
            { "title": "Fact 05", "value": "Value with **markdown** and https://example.com/05" },
            { "title": "Fact 06", "value": "Value with **markdown** and https://example.com/06" },
            { "title": "Fact 07", "value": "Value with **markdown** and https://example.com/07" },
            { "title": "Fact 08", "value": "Value with **markdown** and https://example.com/08" },
            { "title": "Fact 09", "value": "Value with **markdown** and https://example.com/09" },
            { "title": "Fact 10", "value": "Value with **markdown** and https://example.com/10" },
            { "title": "Fact 11", "value": "Value with **markdown** and https://example.com/11" },
            { "title": "Fact 12", "value": "Value with **markdown** and https://example.com/12" }
          ]
        },
        {
          "type": "Container",
          "items": [
            {
              "type": "TextBlock",
              "text": "**TextBlock 01** [link](https://example.com/a) with enough content to exercise markdown conversion.",
              "wrap": true
            },
            {
              "type": "Container",
              "items": [
                { "type": "TextBlock", "text": "**TextBlock 02** [link](https://example.com/b) inside a nested container.", "wrap": true },
                { "type": "TextBlock", "text": "**TextBlock 03** [link](https://example.com/c) inside a nested container.", "wrap": true },
                { "type": "TextBlock", "text": "**TextBlock 04** [link](https://example.com/d) inside a nested container.", "wrap": true },
                { "type": "TextBlock", "text": "**TextBlock 05** [link](https://example.com/e) inside a nested container.", "wrap": true },
                { "type": "TextBlock", "text": "**TextBlock 06** [link](https://example.com/f) inside a nested container.", "wrap": true },
                { "type": "TextBlock", "text": "**TextBlock 07** [link](https://example.com/g) inside a nested container.", "wrap": true },
                { "type": "TextBlock", "text": "**TextBlock 08** [link](https://example.com/h) inside a nested container.", "wrap": true }
              ]
            }
          ]
        }
      ]
    }
  ]
}
```

# How Verified

1. Added unit tests covering:
   - retrieval of stored text preprocessing data;
   - missing and nil element IDs;
   - 500 concurrent reads and writes with final-value assertions.
2. Ran `AdaptiveCardsTextBlockTests` successfully on an iPhone 16 Pro iOS 18.6 simulator.
3. Ran the concurrent accessor test with Thread Sanitizer enabled; no data race was reported.
4. Manually rendered the sample card in ADCIOSVisualizer and confirmed the synchronized accessor returned the expected data across repeated TextBlock renders.
