### PR TITLE
fix(ci): always run iOS Framework Unit Tests, even when the UI suite fails

### DIFF
--- a/.pipelines/templates/ios-ci-template.yml
+++ b/.pipelines/templates/ios-ci-template.yml
@@ -58,3 +58,7 @@ steps:
 
     xcodebuild test       -workspace AdaptiveCards.xcworkspace       -scheme AdaptiveCards       -sdk iphonesimulator       -destination "$DEST"       CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO       | xcpretty -r junit --no-color
   displayName: 'Framework Unit Test'
+  # The SDK's own unit tests must run even when the sample-app UI suite fails.
+  # Without this they inherit the default condition: succeeded() and are silently
+  # skipped whenever a flaky UI test trips, leaving the framework untested.
+  condition: succeededOrFailed()


### PR DESCRIPTION
## Problem

The iOS CI template runs two test steps in sequence:

| Step | Scheme | Covers |
|---|---|---|
| Sample App Unit Test | `ADCIOSVisualizer` | sample app unit tests + `ADCIOSVisualizerUITests` |
| Framework Unit Test | `AdaptiveCards` | the SDK's own unit tests |

The second step has no `condition:`, so it inherits the default `condition: succeeded()` and is **skipped whenever the first step fails**.

Because the first step includes the XCUITest suite, any flaky UI test silently prevents the SDK's unit tests from running at all.

## Evidence

Observed on build `12557` (PR #723). Task breakdown:

```
Sample App Unit Test   ->  failed    (testDynamicTypeaheadSearchFromChoiceset)
Framework Unit Test    ->  skipped
```

The failure itself was pure infrastructure:

```
✗ testDynamicTypeaheadSearchFromChoiceset
  Failed to scroll to visible (by AX action) Button,
  {{5.3, 46.4}, {123.3, 9.3}}, label: 'Delete All Cards',
  error: Error kAXErrorCannotComplete
```

That PR added five new unit tests to the `AdaptiveCards` scheme. None of them appear anywhere in the build log — the only bundles that executed were `ADCIOSVisualizerTests` (65 tests) and `ADCIOSVisualizerUITests` (19 tests, 1 failure). The tests written specifically to validate the change never ran.

This is not a one-off. The iOS UI suite in this repo has a documented flake history — `testPopoverRendering`, `testPopoverInput1SuccessfulSubmission`, `Simulator device failed to launch …xctrunner`, `Timed out waiting for AX loaded notification`, and now `testDynamicTypeaheadSearchFromChoiceset`. Every one of those occurrences also skipped the framework unit tests.

The net effect is that iOS SDK unit-test coverage is quietly lower than the check marks imply, and the signal is worst exactly when it matters most — on a red build, where you most want to know whether the unit tests still pass.

## Change

Add `condition: succeededOrFailed()` to the Framework Unit Test step so the SDK unit tests always run.

## Why this is safe

- **Scoped to one step.** The `Sample App Unit Test` step is untouched and still gates on `succeeded()`.
- **Does not mask failures.** The job still fails if either step fails; this only stops the second step being *skipped*. A genuine framework regression will now surface rather than being hidden behind an unrelated UI flake.
- **No behaviour change on green builds** — the step already ran in that case.

Verified the template still parses and that the condition lands on the intended step only:

```
Installing dependency via pod      condition=None
Sample App Unit Test               condition=None
Framework Unit Test                condition=succeededOrFailed()
```

## Related

- #723 — where this was found; its five new unit tests are still unexecuted because of it
- #664 — same class of problem on the Android side (flaky `packageRelease` gating the build)
